### PR TITLE
Update code example in pbab README.md

### DIFF
--- a/powered-by-art-blocks-pbab-onboarding/pbab-101/README.md
+++ b/powered-by-art-blocks-pbab-onboarding/pbab-101/README.md
@@ -35,7 +35,7 @@ description: A high level process-map for PBAB onboarding.
     const genArt = new ethers.Contract('<CORE CONTRACT ADDRESS>', GEN_ART_ABI, provider)
     const { paused } = await genArt.projectScriptInfo('<PROJECT ID>')
     const { invocations, maxInvocations, pricePerTokenInWei, active, currencyAddress } = await genArt.projectTokenInfo('<PROJECT ID>')
-    if (invocations >= maxInvocations || paused || !active) {
+    if (Number(invocations) >= Number(maxInvocations) || paused || !active) {
       // Disable purchase
       return
     }


### PR DESCRIPTION
Tiny proposal - transform `invocations` and `maxInvocations` explicitly to a number in code example. The reason: type coercion works incorrectly when using some libraries: e.g. [@ethersproject/contracts](https://www.npmjs.com/package/@ethersproject/contracts), which returns BigNumber object instead of string.

![Screenshot 2021-11-17 at 8 12 08 PM](https://user-images.githubusercontent.com/13902831/142724267-3e112c45-e98c-4dc5-ab09-c95c61ef0c4c.png)