### PR TITLE
Add PBAB royalty pre-setup steps

### DIFF
--- a/powered-by-art-blocks-pbab-onboarding/pbab-101/pbab-royalty-registry-setup.md
+++ b/powered-by-art-blocks-pbab-onboarding/pbab-101/pbab-royalty-registry-setup.md
@@ -20,8 +20,16 @@ Additional Payee | defined on PBAB core contract | defined on PBAB contract
 
 ## Required Setup
 
-Two setup steps are required before Art Blocks PBAB contracts will integrate properly with the Royalty Registry:
+The following steps are required before Art Blocks PBAB contracts will integrate properly with the Royalty Registry.
 
+A. Pre-setup:
+  - Ensure every project has the desired artist royalty percentage set on the PBAB contract.
+    - IMPORTANT: This percentage represents the percentage of the total token sale that will be paid to combination of artist & additional payee. It is typically 5%. Additionally, the default 2.5% to PBAB platform and 2.5% to render provider will be also added by the Royalty Registry override contracts below.
+    - **Only artists** may update their project's royalty percentage. They can call `updateProjectSecondaryMarketRoyaltyPercentage(<_projectId>, <_royaltyPercentage>)` on the PBAB contract from their artist wallet. Typically royalty percentage would be the number 5, representing 5%.
+   >**Note:** This percentage is different that what OpenSea has asked us to do with their off-chain royalty system. In the old system, typically 5%+2.5%+2.5%=10% was set on OpenSea's website because they only supported bulk payments to a single address. In the new on-chain system, payments to more than a single address will be supported.
+
+
+B. Royalty Registry Integration:
 1. Create a new override on the Royalty Registry for your PBAB core contract
    - View the Royalty Registry's mainnet registry contract on etherscan: [https://etherscan.io/address/0xad2184fb5dbcfc05d8f056542fb25b04fa32a95d#writeProxyContract](https://etherscan.io/address/0xad2184fb5dbcfc05d8f056542fb25b04fa32a95d#writeProxyContract)
    - Using the `Connect to Web3` button, connect your PBAB `admin` wallet to etherscan when on the "Write as Proxy" tab.


### PR DESCRIPTION
Based on conversations and observations with partners, I've noticed that many projects don't define artist royalty to 5%. The typical non-5% values I have seen are 0% (due to artist never setting their on-chain royalty percentage) and 10% (due to thinking that the 2.5% to platform and 2.5% to render provider should be included in the percentage).

Adding some pre-setup steps to Royalty Registry integration steps to try and prevent issues when partners switch to the Royalty Registry.

@ABDruid if you could handle the comms on this to partners before they flip the switch in OpenSea (in the future), that would be awesome 💯 💯 