### PR TITLE
Re-organize minter-related documentation

### DIFF
--- a/art-blocks-engine-onboarding/art-blocks-engine-101/Engine-royalty-registry-setup.md
+++ b/art-blocks-engine-onboarding/art-blocks-engine-101/Engine-royalty-registry-setup.md
@@ -8,9 +8,13 @@ order: 500
 
 The [Royalty Registry](https://royaltyregistry.xyz/lookup) is an on-chain tool used by many marketplaces ((soon) OpenSea, Coinbase NFT, etc.) to query royalty payment addresses and percentages when a token is sold. The Royalty Registry lives on the Ethereum blockchain and is decentralized.
 
-> :warning: Art Blocks Engine contracts integrate with the Royalty Registry directly to handle many projects and artists on a single contract. Please do not use the [Royalty Registry's "Configure" UI](https://royaltyregistry.xyz/configure) to configure the royalties for your Engine contracts. Doing so will result in incorrect royalty payments across many projects. Instead, see the documentation below.
+!!!danger
+Art Blocks Engine contracts integrate with the Royalty Registry directly to handle many projects and artists on a single contract. Please do not use the [Royalty Registry's "Configure" UI](https://royaltyregistry.xyz/configure) to configure the royalties for your Engine contracts. Doing so will result in incorrect royalty payments across many projects. Instead, see the documentation below.
+!!!
 
-> Note that the [Royalty Registry's "Lookup" UI](https://royaltyregistry.xyz/lookup) is a great tool for confirming that your Engine contracts are configured correctly after the configuration steps below have been completed.
+!!!info
+Note that the [Royalty Registry's "Lookup" UI](https://royaltyregistry.xyz/lookup) is a great tool for confirming that your Engine contracts are configured correctly after the configuration steps below have been completed.
+!!!
 
 ## Royalty Payment Addresses
 

--- a/creator-onboarding/curated-checklist.md
+++ b/creator-onboarding/curated-checklist.md
@@ -2,6 +2,7 @@
 order: -100
 description: A project checklist to walk through for Curated projects.
 ---
+
 # Checklist for Curated Projects
 
 !!!danger
@@ -14,11 +15,7 @@ Before proceeding to mainnet upload, please verify that your script behaves as e
 2. Ensure your wallet is funded with enough ETH to pay the gas fees for the upload and unpausing process. For more information on the estimated cost of these steps, [click here.](readme/readme.md#cost)
 3. Submit one field at a time. Wait for that transaction to clear before attempting the next field.
 4. When you upload your script, please copy it exactly from testnet.
-5. Include the following in the Project Base URI field: `https://api.artblocks.io/token/`
-   * **Important:** If you are setting this field for an Engine project, rather than an Art Blocks project directly, the `baseTokenURI` field should follow a slightly different structure. Please see the [Art Blocks Engine documentation](../art-blocks-engine-onboarding/art-blocks-engine-101/adding-new-project-shells.md) for more info.
-6. As [noted in the main documentation overview](readme/readme.md), please ensure that you are only setting a currency address if you are using some custom ERC20-compatible token (e.g., DAI) for the sale of your work. This field **should not** be set if you are accepting ETH as your payment type.
-7. Please double-check, triple-check, and then check again the generated [features script](readme/features.md) results on staging to ensure they are 100% accurate. This is **extremely important** to get right, as it changes to fix any bugs you may introduce in this script may have a massive impact on how the artwork is perceived by collectors and may cause confusion in the secondary market. It is **your responsibility** to guarantee that your features script is properly verified in the artist staging environment.
-Add tags (add below) 
+5. Please double-check, triple-check, and then check again the generated [features script](readme/features.md) results on staging to ensure they are 100% accurate. This is **extremely important** to get right, as it changes to fix any bugs you may introduce in this script may have a massive impact on how the artwork is perceived by collectors and may cause confusion in the secondary market. It is **your responsibility** to guarantee that your features script is properly verified in the artist staging environment.
 
 ## Features
 
@@ -29,14 +26,14 @@ Add tags (add below)
 
 ## Tags
 
-* Add relevant tags to your project. More on tags [here](https://docs.artblocks.io/creator-docs/creator-onboarding/readme/project-form-fields-guide/). 
+- Add relevant tags to your project. More on tags [here](https://docs.artblocks.io/creator-docs/creator-onboarding/readme/project-form-fields-guide/).
 
 ## Economics
 
 1. Review the Project Pricing Model for Dutch auctions [here](https://docs.artblocks.io/creator-docs/creator-onboarding/readme/project-pricing-model/#project-pricing-dutch-auction-settings)
 2. Consider the overall economics of your project for a successful release.
 3. Artists can only have one active project at a time.
-4. As a note, we require artists to take a 6 month cooldown period between considerations for Curated projects. The cooldown period begins when your project sells out (i.e. when minting is 100% complete). 
+4. As a note, we require artists to take a 6 month cooldown period between considerations for Curated projects. The cooldown period begins when your project sells out (i.e. when minting is 100% complete).
 
 ## Charity Component
 
@@ -45,49 +42,57 @@ To maintain our commitment to charitable giving, we ask artists to consider dona
 Learn more about Charitable Donation [here](https://docs.artblocks.io/creator-docs/creator-onboarding/readme/charitable-donations/).
 
 ## Approve additional payee info for primary and secondary sales⛽
-Include the wallet addresses for primary and secondary sales to be distributed. Once submitted, the details will be approved by the Art Team. If you do not have additional wallet addresses that will receive funds from primary or secondary sales you must input `0x0000000000000000000000000000000000000000` in the blank fields. 
 
+Include the wallet addresses for primary and secondary sales to be distributed. Once submitted, the details will be approved by the Art Team. If you do not have additional wallet addresses that will receive funds from primary or secondary sales you must input `0x0000000000000000000000000000000000000000` in the blank fields.
 
 ## Mint #0
+
 1. **Note**: Mint #0 will be completed with the Set Price minter. Set the minter to Set Price ETH with the set price as your Dutch Auction’s base price for Mint #0
 2. **Before** minting Mint #0, ensure that your "additional payee wallet" has been set for the same configuration that you will use it for in your project release. E.g., if you are using the "additional payee wallet" field to donate to charity at the time of mint, you must set this before minting your #0. This is done to ensure that this full functionality is tested end-to-end as part of the mint #0 process, and that there are no issues with the wallet selected for the additional payee. **Please note: Art Blocks does not currently support sending primary sales payments into a multi-sig contract and there are known issues when attempting to do so. While we plan to update our minting smart contracts in the near future to resolve this, multi-sig wallets should not be used for this purpose at this time.**
-3. Once your project information has been uploaded, **please confirm in your artist DM that you're ready for mint #0**. The Art Blocks Team will look over your project shell and then give you the go-ahead to mint #0. 
+3. Once your project information has been uploaded, **please confirm in your artist DM that you're ready for mint #0**. The Art Blocks Team will look over your project shell and then give you the go-ahead to mint #0.
 4. Mint #0 must occur before your release can be scheduled.
 
-### Initiating your MinterSuite choice
+### Payout Details
 
-If you are using the Dutch auction - Exponential Price Decrease with/without settlement or Dutch auction - Linear Price Decrease, your project will be unpaused prior to your auction’s start time. Once your project page is public, your project can be unpaused under the Danger tab any time prior to the starting time of your auction. We recommend unpausing projects the morning of your release. Once unpaused, your project will be marked as “Upcoming” and the Dutch auction will automatically begin at your start time, leaving the beginning of the auction hands-free. 
+Be sure that you've input information in all field forms. If you do not have an additional payee for primary or secondary sales, you may put `0x0000000000000000000000000000000000000000` in the field and 0% for the payee percentage.
 
-### Payout Details 
+## Initiating your Minter Suite choice
 
-Be sure that you've input information in all field forms. If you do not have an additional payee for primary or secondary sales, you may put `0x0000000000000000000000000000000000000000` in the field and 0% for the payee percentage. 
+We have a variaty of minters available for you to choose from to best suit your project.
+
+For an overview of all minters available for artists, please see the [Minter Suite](readme/minter-suite.md) page.
+
+For more detailed instructions on how to configure your selected minter, please see the [Minter section of the Project Form Fields Guide](readme/project-form-fields-guide.md#minter) .
+
+!!!info
+If you are using the `Dutch auction - Exponential Price Decrease` (with or without settlement) or `Dutch auction - Linear Price Decrease`, your project will be unpaused prior to your auction’s start time, and the minter will automatically open for minting at the start time. Once your project page is public, your project can be unpaused under the Danger tab any time prior to the starting time of your auction. We recommend unpausing projects the morning of your release. Once unpaused, your project will be marked as “Upcoming” and the dutch auction will automatically begin at your start time, leaving the beginning of the auction hands-free.
 
 ## Scheduling
 
-* Once mint #0 and the features script are in place, Art Blocks will work with you to schedule/announce your curated release.
-* Curated releases will include an artist feature with a Q\&A to be gathered following scheduling.
-* Curated artists will also have an artist channel created in Discord. To pin messages in your artist channel, you must enable two-factor authentication within User Settings > My Account in Discord.
-* After your project has been scheduled, you are free to announce and promote your project on your social media.
+- Once mint #0 and the features script are in place, Art Blocks will work with you to schedule/announce your curated release.
+- Curated releases will include an artist feature with a Q\&A to be gathered following scheduling.
+- Curated artists will also have an artist channel created in Discord. To pin messages in your artist channel, you must enable two-factor authentication within User Settings > My Account in Discord.
+- After your project has been scheduled, you are free to announce and promote your project on your social media.
 
-## Pre-Drop Talk 
+## Pre-Drop Talk
 
 Pre-Drop Talks happen on Twitter Spaces 15 minutes prior to the release of your project. A member of the Community Team will ask you a series of questions to help collectors get to know more about your creative process and the decisions behind your project. Pre-drop talks are announced on Twitter a few days before release, and you’ll be connected with the host of your talk after your project is announced in #upcoming-projects. You will receive interview questions in advance of the live show. If you do not have a Twitter account, the Community Team will explore alternative ways to host this conversation with you.
 
 ## Unpausing
 
-* When it's time, you'll click the Unpause button under the Danger tab.
-* When unpausing the project, please send in the tx 30 seconds prior to the top of the hour. To unpause the project, please send high gas (2-3x what is suggested as high gas on https://etherscan.io/gastracker). If you have questions about what you should set your gas to, please ask in your project DM and the Art Blocks Team can advise.
-* Once the transaction clears, your project will be live for minting.
+- When it's time, you'll click the Unpause button under the Danger tab.
+- When unpausing the project, please send in the tx 30 seconds prior to the top of the hour. To unpause the project, please send high gas (2-3x what is suggested as high gas on https://etherscan.io/gastracker). If you have questions about what you should set your gas to, please ask in your project DM and the Art Blocks Team can advise.
+- Once the transaction clears, your project will be live for minting.
 
 ## Rarities
 
-* Do not discuss odds or feature rarities about your project until it is completely sold out.
+- Do not discuss odds or feature rarities about your project until it is completely sold out.
 
 ## Finishing Steps
 
-1. Once your project is completely sold out, you may reset the Additional Payee Percentage to 0% for any charitable giving that was conducted during minting. If removing, you will need to edit the secondary payee info to your wallet or set the percentage to 0. In order to successfully complete this change, you will need to input information in all fields in the Payout tab. 
+1. Once your project is completely sold out, you may reset the Additional Payee Percentage to 0% for any charitable giving that was conducted during minting. If removing, you will need to edit the secondary payee info to your wallet or set the percentage to 0. In order to successfully complete this change, you will need to input information in all fields in the Payout tab.
 2. You may also remove any language from your Project Description that was specifically included to describe sales mechanics.
 3. Report final charity donation totals in your Mainnet DM
 4. Please fill out the appropriate form to add bot-support to your Discord channel for your completed project: https://github.com/ArtBlocks/artbot/issues/new/choose.
-5. Personalize your OpenSea Collection. Learn more about doing so (here)[https://docs.artblocks.io/creator-docs/creator-onboarding/readme/opensea-personalization/]. 
+5. Personalize your OpenSea Collection. Learn more about doing so (here)[https://docs.artblocks.io/creator-docs/creator-onboarding/readme/opensea-personalization/].
 6. Last, please feel free to hang out as much or as little as you'd like in your channel going forward. If you plan to take an extended amount of time away from the community in the next month, we'd appreciate it if you would communicate that you are disconnecting to your collectors in case they have any questions in the interim.

--- a/creator-onboarding/presents.md
+++ b/creator-onboarding/presents.md
@@ -68,24 +68,6 @@ For more detailed instructions on how to configure your selected minter, please 
 If you are using the `Dutch auction - Exponential Price Decrease` (with or without settlement) or `Dutch auction - Linear Price Decrease`, your project will be unpaused prior to your auction’s start time, and the minter will automatically open for minting at the start time. Once your project page is public, your project can be unpaused under the Danger tab any time prior to the starting time of your auction. We recommend unpausing projects the morning of your release. Once unpaused, your project will be marked as “Upcoming” and the dutch auction will automatically begin at your start time, leaving the beginning of the auction hands-free.
 !!!
 
-## Allowlist:
-
-The allowlist minter is available for projects in the Presents, Explorations, and Collaborations Collections. This process is supported through the Art Blocks platform as a tool to mitigate botting and to create access to the minting experience for established collectors and to new participants. Art Blocks’ role in the allowlist feature is through smart contract development. Artists are responsible for the selection of allowlisted minters.
-
-1. Artists can choose the list of addresses to allow as well as the number of mints allowed per-wallet. Currently, artists are responsible for crafting their allowlist and uploading a comma-separated list of ETH addresses in a .txt or .CSV file to the minter option.
-   a. [Premint](https://www.premint.xyz/) is a super helpful tool for creating an allowlist by using social channels to reach collectors, friends, family, etc. In addition, Art Blocks hosts a Python script for retrieving & snapshotting either a list of all Art Blocks token holders or the token-holders of a specific project.
-2. Allowlists are available before the public dutch auction. Artists are responsible for unpausing their project the day prior.
-3. Allowlists are sold via a fixed price. The Art Blocks Team recommends a fixed price that is 0.05-0.1 ETH above the auction’s resting price.
-4. **Note** The allowlist feature is not a reserve feature. All allowlisted wallets will have access to purchase a mint and there will not be a limit set on the total number of mints via the allowlist.
-5. Artists must update the Sales Notes section with the criteria for the allowlist, the open date/time for the allowlist, and the close date/time for the allowlist. We also recommend that artists post in our #artist-announcements channel to announce the opening of an allowlist mint.
-
-**To set the allowlist minter:**
-
-1. Select Set Price- ETH, Allowlisted Users Only
-2. Upload your .csv or .txt file
-3. Enter your fixed price
-4. We recommend leaving the mint per wallet limit to 1 for allowlist . If you would like to adjust this, please let the Art Blocks Team know.
-
 ## Scheduling
 
 - Once mint #0 and the features script are in place, Art Blocks will work with you to schedule/announce your release.

--- a/creator-onboarding/presents.md
+++ b/creator-onboarding/presents.md
@@ -2,6 +2,7 @@
 order: -200
 description: A project checklist to walk through for Presents projects.
 ---
+
 # Checklist for Presents Projects
 
 !!!danger
@@ -14,10 +15,7 @@ Before proceeding to mainnet upload, please verify that your script behaves as e
 2. Ensure your wallet is funded with enough ETH to pay the gas fees for the upload and unpausing process. For more information on the estimated cost of these steps, [click here.](readme/readme.md#cost)
 3. Submit one field at a time. Wait for that transaction to clear before attempting the next field.
 4. When you upload your script, please copy it exactly from testnet.
-5. Include the following in the Project Base URI field: `https://api.artblocks.io/token/`
-   * **Important:** If you are setting this field for an Engine project, rather than an Art Blocks project directly, the `baseTokenURI` field should follow a slightly different structure. Please see the [Art Blocks Engine documentation](../art-blocks-engine-onboarding/art-blocks-engine-101/adding-new-project-shells.md) for more info.
-6. As [noted in the main documentation overview](readme/readme.md), please ensure that you are only setting a currency address if you are using some custom ERC20-compatible token (e.g., DAI) for the sale of your work. This field **should not** be set if you are accepting ETH as your payment type.
-7. Please double-check, triple-check, and then check again the generated [features script](readme/features.md) results on staging to ensure they are 100% accurate. This is **extremely important** to get right, as it changes to fix any bugs you may introduce in this script may have a massive impact on how the artwork is perceived by collectors and may cause confusion in the secondary market. It is **your responsibility** to guarantee that your features script is properly verified in the artist staging environment.
+5. Please double-check, triple-check, and then check again the generated [features script](readme/features.md) results on staging to ensure they are 100% accurate. This is **extremely important** to get right, as it changes to fix any bugs you may introduce in this script may have a massive impact on how the artwork is perceived by collectors and may cause confusion in the secondary market. It is **your responsibility** to guarantee that your features script is properly verified in the artist staging environment.
 
 ## Features
 
@@ -28,7 +26,7 @@ Before proceeding to mainnet upload, please verify that your script behaves as e
 
 ## Tags
 
-Add relevant tags to your project. More on tags [here](https://docs.artblocks.io/creator-docs/creator-onboarding/readme/project-form-fields-guide/). 
+Add relevant tags to your project. More on tags [here](https://docs.artblocks.io/creator-docs/creator-onboarding/readme/project-form-fields-guide/).
 
 ## Economics
 
@@ -38,64 +36,75 @@ Add relevant tags to your project. More on tags [here](https://docs.artblocks.io
 4. In order to submit a new project, your previous project must be closed (sold out/completed).
 
 ## Charity Component
+
 To maintain our commitment to charitable giving, we ask artists to consider donating 25% of sales above the resting price via Dutch auction to a charity of their choice. If you elect to participate in this way, please determine your chosen charity, and confirm its eligibility, before mint #0. To whom and how you donate is entirely up to you. Art Blocks does not require you to donate any proceeds in order to engage with our platform. If you do elect to donate to a charity, it is advisable to consider whether the charity which you choose to support qualifies under United States tax law to receive tax-deductible donations. If your project designates only one primary wallet, you may use the additional payee field to manage on-chain donations. All revenue may also be routed to a single wallet and donated after your drop. We encourage you to consult with a tax professional to understand any potential tax implications of your planned giving, as these can be widely variable.
 
 Learn more about Charitable Donation [here](https://docs.artblocks.io/creator-docs/creator-onboarding/readme/charitable-donations/).
 
 ## Approve additional payee info for primary and secondary sales⛽
-Include the wallet addresses for primary and secondary sales to be distributed. Once submitted, the details will be approved by the Art Team. If you do not have additional wallet addresses that will receive funds from primary or secondary sales you must input `0x0000000000000000000000000000000000000000` in the blank fields. 
+
+Include the wallet addresses for primary and secondary sales to be distributed. Once submitted, the details will be approved by the Art Team. If you do not have additional wallet addresses that will receive funds from primary or secondary sales you must input `0x0000000000000000000000000000000000000000` in the blank fields.
 
 ## Mint #0
 
 1. Note: Mint #0 will be completed with the Set Price minter. If you are using a fixed price, your project will be unpaused under the Danger tab right before your project’s release. Once a project using Set Price - ETH or Set Price - Custom ERC20 is unpaused, it will be live for minting. If your project will be sold via Dutch auction, please set the minter to Set Price ETH with the set price as your Dutch Auction’s base price for Mint #0.
-2.  **Before** minting Mint #0, ensure that your "additional payee wallet" has been set for the same configuration that you will use it for in your project release. E.g., if you are using the "additional payee wallet" field to donate to charity at the time of mint, you must set this before minting your #0. This is done to ensure that this full functionality is tested end-to-end as part of the mint #0 process, and that there are no issues with the wallet selected for the additional payee. **Please note: Art Blocks does not currently support sending primary sales payments into a multi-sig contract and there are known issues when attempting to do so. While we plan to update our minting smart contracts in the near future to resolve this, multi-sig wallets should not be used for this purpose at this time.**
-3. Once your project information has been uploaded, **please confirm in your artist DM that you're ready for mint #0**. The Art Blocks Team will look over your project shell and then give you the go-ahead to mint #0. 
+2. **Before** minting Mint #0, ensure that your "additional payee wallet" has been set for the same configuration that you will use it for in your project release. E.g., if you are using the "additional payee wallet" field to donate to charity at the time of mint, you must set this before minting your #0. This is done to ensure that this full functionality is tested end-to-end as part of the mint #0 process, and that there are no issues with the wallet selected for the additional payee. **Please note: Art Blocks does not currently support sending primary sales payments into a multi-sig contract and there are known issues when attempting to do so. While we plan to update our minting smart contracts in the near future to resolve this, multi-sig wallets should not be used for this purpose at this time.**
+3. Once your project information has been uploaded, **please confirm in your artist DM that you're ready for mint #0**. The Art Blocks Team will look over your project shell and then give you the go-ahead to mint #0.
 4. Mint #0 must occur before your release can be scheduled.
 
-### Payout Details 
+### Payout Details
 
-Be sure that you've input information in all field forms. If you do not have an additional payee for primary or secondary sales, you may put `0x0000000000000000000000000000000000000000` in the field and 0% for the payee percentage. 
+Be sure that you've input information in all field forms. If you do not have an additional payee for primary or secondary sales, you may put `0x0000000000000000000000000000000000000000` in the field and 0% for the payee percentage.
 
-## Initiating your MinterSuite choice
+## Initiating your Minter Suite choice
 
-If you are using the Dutch auction - Exponential Price Decrease with/without settlement or Dutch auction - Linear Price Decrease, your project will be unpaused prior to your auction’s start time. Once your project page is public, your project can be unpaused under the Danger tab any time prior to the starting time of your auction. We recommend unpausing projects the morning of your release. Once unpaused, your project will be marked as “Upcoming” and the dutch auction will automatically begin at your start time, leaving the beginning of the auction hands-free. 
+We have a variaty of minters available for you to choose from to best suit your project.
 
-## Scheduling
+For an overview of all minters available for artists, please see the [Minter Suite](readme/minter-suite.md) page.
 
-* Once mint #0 and the features script are in place, Art Blocks will work with you to schedule/announce your release.
-* After your project has been scheduled, you are free to announce and promote your project on your social media.
-* Refer to our Marketing 101 Guide [here](https://docs.artblocks.io/creator-docs/creator-onboarding/readme/marketing101/)
+For more detailed instructions on how to configure your selected minter, please see the [Minter section of the Project Form Fields Guide](readme/project-form-fields-guide.md#minter) .
+
+!!!info
+If you are using the `Dutch auction - Exponential Price Decrease` (with or without settlement) or `Dutch auction - Linear Price Decrease`, your project will be unpaused prior to your auction’s start time, and the minter will automatically open for minting at the start time. Once your project page is public, your project can be unpaused under the Danger tab any time prior to the starting time of your auction. We recommend unpausing projects the morning of your release. Once unpaused, your project will be marked as “Upcoming” and the dutch auction will automatically begin at your start time, leaving the beginning of the auction hands-free.
+!!!
 
 ## Allowlist:
+
 The allowlist minter is available for projects in the Presents, Explorations, and Collaborations Collections. This process is supported through the Art Blocks platform as a tool to mitigate botting and to create access to the minting experience for established collectors and to new participants. Art Blocks’ role in the allowlist feature is through smart contract development. Artists are responsible for the selection of allowlisted minters.
 
 1. Artists can choose the list of addresses to allow as well as the number of mints allowed per-wallet. Currently, artists are responsible for crafting their allowlist and uploading a comma-separated list of ETH addresses in a .txt or .CSV file to the minter option.
- a. [Premint](https://www.premint.xyz/) is a super helpful tool for creating an allowlist by using social channels to reach collectors, friends, family, etc. In addition, Art Blocks hosts a Python script for retrieving & snapshotting either a list of all Art Blocks token holders or the token-holders of a specific project.
+   a. [Premint](https://www.premint.xyz/) is a super helpful tool for creating an allowlist by using social channels to reach collectors, friends, family, etc. In addition, Art Blocks hosts a Python script for retrieving & snapshotting either a list of all Art Blocks token holders or the token-holders of a specific project.
 2. Allowlists are available before the public dutch auction. Artists are responsible for unpausing their project the day prior.
 3. Allowlists are sold via a fixed price. The Art Blocks Team recommends a fixed price that is 0.05-0.1 ETH above the auction’s resting price.
 4. **Note** The allowlist feature is not a reserve feature. All allowlisted wallets will have access to purchase a mint and there will not be a limit set on the total number of mints via the allowlist.
 5. Artists must update the Sales Notes section with the criteria for the allowlist, the open date/time for the allowlist, and the close date/time for the allowlist. We also recommend that artists post in our #artist-announcements channel to announce the opening of an allowlist mint.
 
 **To set the allowlist minter:**
+
 1. Select Set Price- ETH, Allowlisted Users Only
 2. Upload your .csv or .txt file
 3. Enter your fixed price
 4. We recommend leaving the mint per wallet limit to 1 for allowlist . If you would like to adjust this, please let the Art Blocks Team know.
 
-## Pre-Drop Talk 
+## Scheduling
+
+- Once mint #0 and the features script are in place, Art Blocks will work with you to schedule/announce your release.
+- After your project has been scheduled, you are free to announce and promote your project on your social media.
+- Refer to our Marketing 101 Guide [here](https://docs.artblocks.io/creator-docs/creator-onboarding/readme/marketing101/)
+
+## Pre-Drop Talk
 
 Pre-Drop Talks happen on Twitter Spaces 15 minutes prior to the release of your project. A member of the Community Team will ask you a series of questions to help collectors get to know more about your creative process and the decisions behind your project. Pre-drop talks are announced on Twitter a few days before release, and you’ll be connected with the host of your talk after your project is announced in #upcoming-projects. You will receive interview questions in advance of the live show. If you do not have a Twitter account, the Community Team will explore alternative ways to host this conversation with you.
 
 ## Unpausing
 
-* When it's time, you'll click the Unpause button under the Danger tab.
-* When unpausing the project, please send in the tx 30 seconds prior to the top of the hour. To unpause the project, please send high gas (2-3x what is suggested as high gas on https://etherscan.io/gastracker). If you have questions about what you should set your gas to, please ask in your project DM and the Art Blocks Team can advise.
-* Once the transaction clears, your project will be live for minting.
-
+- When it's time, you'll click the Unpause button under the Danger tab.
+- When unpausing the project, please send in the tx 30 seconds prior to the top of the hour. To unpause the project, please send high gas (2-3x what is suggested as high gas on https://etherscan.io/gastracker). If you have questions about what you should set your gas to, please ask in your project DM and the Art Blocks Team can advise.
+- Once the transaction clears, your project will be live for minting.
 
 ## Rarities
 
-* Do not discuss odds or feature rarities about your project until it is completely sold out.
+- Do not discuss odds or feature rarities about your project until it is completely sold out.
 
 ## Finishing Steps
 
@@ -103,6 +112,3 @@ Pre-Drop Talks happen on Twitter Spaces 15 minutes prior to the release of your 
 2. You may also remove any language from your Project Description to describe sales mechanics.
 3. Report final charity donation totals in your artist DM
 4. **[For previously Curated only]** Please fill out the appropriate form to add bot support to your Discord channel for your completed project: https://github.com/ArtBlocks/artbot/issues/new/choose.
-
-
-

--- a/creator-onboarding/readme/minter-suite.md
+++ b/creator-onboarding/readme/minter-suite.md
@@ -1,0 +1,69 @@
+---
+order: 851
+---
+
+# Minter Suite
+
+This page provides an overview of the Art Blocks Minter Suite, which enables artists to choose how they distribute their artwork to collectors. on a per-project basis.
+
+The current available Minter options are discussed below. We are continually expanding our minter suite over time.
+
+!!!info
+For details on determining proper pricing and configuring your project's minter, please see the [Minter section in the Project Form Fields Guide](project-form-fields-guide.md#minter).
+!!!
+
+## `Set Price - ETH`
+
+The set price minter is used for fixed price releases. It is the simplest minter and prices all tokens at the same price, in ETH.
+
+## `Dutch Auction with Settlement - Exponential Price Decrease`
+
+When this minter is used, all collectors will pay the same net-price as the last purchaser. This is typically the most fair and equitable Dutch auction type for buyers because all buyers pay the same price, making it the recommended auction type for most projects.
+
+Collectors who purchase above the lowest price will be able to claim a settlement after the auction. The settlement will be the difference between the price they purchased at and the last purchase price. All funds are held non-custodially by the smart contract until the auction ends and revenues are collected by the artist.
+
+!!!info
+We are currently rolling this minter out in production. For a period of time, we will continue to allow DAs without settlement, but we would like to move towards all DAs including settlement in the future. It is important to note that we do not expect the overall revenue that artists receive to decrease between this option and the exponential Dutch auction without settlement, due to how blockchain mechanics interact with the Dutch auction mechanics.
+!!!
+
+Note that the Dutch auction with settlement minter can be coupled with an allowlist minter. In this case, the allowlist portion of the auction must come before the dutch auction with settlement.
+
+## `Automated Exponential Dutch Auction`
+
+For exponential Dutch auctions, artists specify the starting price, ending price, and the half-life for price drops. Collectors will pay more for tokens purchased earlier in the auction, and less for tokens purchased later in the auction.
+
+## `Automated Linear Dutch Auction`
+
+For linear Dutch auctions, artists will specify the starting price, ending price, starting time, and ending time of the auction. The price will then gradually decrease each block over the total auction time. Collectors will pay more for tokens purchased earlier in the auction, and less for tokens purchased later in the auction.
+
+## `Set price in custom ERC20`
+
+Set price in ERC20 is a fixed price minter that allows accepting any ERC20 token as payment for your sale of tokens. In addition to specifying a fixed price, artists will specify the ERC20 token address for the custom token sale.
+
+## `Set Price - ETH, Allowlisted Users Only`
+
+This minter enables the artist to limit minting of their project's tokens to a predetermined list of wallet addresses. Artists upload a list of allowlisted wallet addresses, and may also specify the number of mints allowed per wallet. Mints per wallet can be set to a value, or may be set to unlimited (limited only by project maximum invocations).
+
+Artists are responsible for crafting their allowlist and uploading a comma-separated list of ETH addresses in a .txt or .CSV file to the artist dashboard. These wallet addresses cannot be ENS names, but list the full address of the wallet. [Premint](https://www.premint.xyz/) is a super helpful tool for creating an allowlist by using social channels to reach collectors, friends, family, etc. In addition, Art Blocks hosts a [Python script](https://github.com/ArtBlocks/artblocks-community-tooling/tree/main/SnapshotABHolders) for retrieving & snapshotting either a list of all Art Blocks token holders or the token-holders of a specific project.
+
+!!!info
+Allowlists use Merkle trees, which enables them to be verified on-chain and to be decentralized. It also is efficient, enabling very large allowlists. For example, ~40,000 wallet addresses were used for the Friendship Bracelet project's allowlist.
+!!!
+
+!!!info
+Note that vault delegation via [Delegate Cash](https://delegate.cash/) is available for the Allowlisted Users minter. For more details please visit this [video walkthrough](https://www.youtube.com/watch?v=2-AgG--zcaw&list=PLSNTJAzmISeZcLm19EhafsGjJXwwgzBbU&index=5).
+!!!
+
+## `Set Price - ETH, Token Holders Only`
+
+This minter allows tokens to be minted with ETH when the purchaser owns a token from one or more allowlisted Art Blocks or Art Blocks Engine project. This contract does not track if a purchaser has/has not minted already (ie. a "mint limit" is not available) -- it simply restricts purchasing to anybody that holds one or more of a specified list of ERC-721 NFTs.
+
+Artists may use the artist dashboard to pre-select a list of allowlisted Art Blocks or Art Blocks Engine projects, of which any valid token holders will be able to purchase for the upcoming project. Note that a "snapshot" won't apply to this minter -- after the project's been made public, users can purchase a token from any allowlisted project and mint freely.
+
+!!!info
+Note that vault delegation via [Delegate Cash](https://delegate.cash/) is available for the Token Holders Only minter. For more details please visit this [video walkthrough](https://www.youtube.com/watch?v=2-AgG--zcaw&list=PLSNTJAzmISeZcLm19EhafsGjJXwwgzBbU&index=5).
+!!!
+
+## Configuring Your Minter
+
+TODO

--- a/creator-onboarding/readme/minter-suite.md
+++ b/creator-onboarding/readme/minter-suite.md
@@ -36,7 +36,7 @@ For exponential Dutch auctions, artists specify the starting price, ending price
 
 For linear Dutch auctions, artists will specify the starting price, ending price, starting time, and ending time of the auction. The price will then gradually decrease each block over the total auction time. Collectors will pay more for tokens purchased earlier in the auction, and less for tokens purchased later in the auction.
 
-## `Set price in custom ERC20`
+## `Set price in Custom ERC20`
 
 Set price in ERC20 is a fixed price minter that allows accepting any ERC20 token as payment for your sale of tokens. In addition to specifying a fixed price, artists will specify the ERC20 token address for the custom token sale.
 
@@ -58,7 +58,7 @@ Note that vault delegation via [Delegate Cash](https://delegate.cash/) is availa
 
 This minter allows tokens to be minted with ETH when the purchaser owns a token from one or more allowlisted Art Blocks or Art Blocks Engine project. This contract does not track if a purchaser has/has not minted already (ie. a "mint limit" is not available) -- it simply restricts purchasing to anybody that holds one or more of a specified list of ERC-721 NFTs.
 
-Artists may use the artist dashboard to pre-select a list of allowlisted Art Blocks or Art Blocks Engine projects, of which any valid token holders will be able to purchase for the upcoming project. Note that a "snapshot" won't apply to this minter -- after the project's been made public, users can purchase a token from any allowlisted project and mint freely.
+Artists may use the artist dashboard to pre-select a list of allowlisted Art Blocks or Art Blocks Engine projects, of which any valid token holders will be able to purchase for the upcoming project. Note that a "snapshot" won't apply to this minter -- after the project has been made public, users can purchase a token from any allowlisted project and mint freely.
 
 !!!info
 Note that vault delegation via [Delegate Cash](https://delegate.cash/) is available for the Token Holders Only minter. For more details please visit this [video walkthrough](https://www.youtube.com/watch?v=2-AgG--zcaw&list=PLSNTJAzmISeZcLm19EhafsGjJXwwgzBbU&index=5).

--- a/creator-onboarding/readme/minter-suite.md
+++ b/creator-onboarding/readme/minter-suite.md
@@ -28,6 +28,10 @@ We are currently rolling this minter out in production. For a period of time, we
 
 Note that the Dutch auction with settlement minter can be coupled with an allowlist minter. In this case, the allowlist portion of the auction must come before the dutch auction with settlement.
 
+!!!info
+For Art Blocks Flagship, please see the [Project Pricing: Dutch Auction Settings](project-pricing-model.md) section for more information on how to determine the appropriate pricing parameters for your auction.
+!!!
+
 ## `Automated Exponential Dutch Auction`
 
 For exponential Dutch auctions, artists specify the starting price, ending price, and the half-life for price drops. Collectors will pay more for tokens purchased earlier in the auction, and less for tokens purchased later in the auction.
@@ -63,7 +67,3 @@ Artists may use the artist dashboard to pre-select a list of allowlisted Art Blo
 !!!info
 Note that vault delegation via [Delegate Cash](https://delegate.cash/) is available for the Token Holders Only minter. For more details please visit this [video walkthrough](https://www.youtube.com/watch?v=2-AgG--zcaw&list=PLSNTJAzmISeZcLm19EhafsGjJXwwgzBbU&index=5).
 !!!
-
-## Configuring Your Minter
-
-TODO

--- a/creator-onboarding/readme/project-form-fields-guide.md
+++ b/creator-onboarding/readme/project-form-fields-guide.md
@@ -1,6 +1,7 @@
 ---
 order: 900
 ---
+
 # Project Form Fields Guide
 
 Below, you'll find a guide to all form fields and buttons within testnet and mainnet project environments.
@@ -20,11 +21,12 @@ The Edit Project button will lead to the back end of your shell, where you will 
 
 ## Project:
 
-### Project name  ⛽📄
+### Project name ⛽📄
 
 This is the public name of your project.
 
-### Artist name  ⛽📄
+### Artist name ⛽📄
+
 This is how your name will appear on Art Blocks. What you choose to enter here is up to your personal preference.
 
 ### Project website ⛽
@@ -34,7 +36,8 @@ This field is optional. The link entered in your project website field should le
 Make sure to enter a fully defined website link, including the `https://`
 
 ### Project description ⛽📄
-The project description is a key opportunity to highlight your intentions and provide an interpretative frame around how you want a viewer/collector to approach your project. If you are struggling with this element, we have a series of prompts to guide your first draft. 
+
+The project description is a key opportunity to highlight your intentions and provide an interpretative frame around how you want a viewer/collector to approach your project. If you are struggling with this element, we have a series of prompts to guide your first draft.
 • Begin with a strong, clear opening sentence.
 
 • Lead with the artistic inquiry; what questions can be prompted or answered through this work?
@@ -57,27 +60,31 @@ Art Blocks recommends selecting a license that aligns with your values as a crea
 
 ## Token:
 
-### Sales Notes 
-This describes project-specific sales mechanics. 
+### Sales Notes
 
-### Charitable Giving Details 
+This describes project-specific sales mechanics.
+
+### Charitable Giving Details
+
 This is where you will describe the charitable giving component of your drop, if applicable. The majority of projects released on Art Blocks choose to earmark at least 25% for this giving opportunity, but the final figure is up to you. An example of a charitable giving description is: `25% of proceeds above the resting price will be donated to non-profit educational organizations in Arizona dedicated to protecting the Sonoran Desert and its Native culture.`
 
 ### Maximum invocations ⛽
+
 This is your total project series size.
 
 ### Base uri ⛽
+
 [Mainnet Only] If you are an artist, your project base uri field should be: https://api.artblocks.io/token/.
 
 ## Script:
 
 ### Script type ⛽📄
 
-Select your script type and the version number of that dependency from the drop-down menu provided.  Artists must define the library AND version (when applicable).
+Select your script type and the version number of that dependency from the drop-down menu provided. Artists must define the library AND version (when applicable).
 
-### Aspect ratio (width/height) 
+### Aspect ratio (width/height)
 
-Your project’s outputs must be dimension agnostic, meaning they will scale  seamlessly to any window size. See more on this [here](readme.md#dimensionless). This field sets the aspect ratio for image renders but does not impact an output’s live view.
+Your project’s outputs must be dimension agnostic, meaning they will scale seamlessly to any window size. See more on this [here](readme.md#dimensionless). This field sets the aspect ratio for image renders but does not impact an output’s live view.
 
 While you can control the aspect ratio, you will have no control over the dimensions of the browser on which your project will be viewed.
 
@@ -85,7 +92,7 @@ Your aspect ratio should be a single number. This will be your token’s width d
 
 ### Render delay 📄
 
-If your piece takes a certain amount of time to render fully, you can type in the render delay to let the server know when to render your output’s thumbnails. This render time will be in milliseconds. If your algorithm is GPU intensive, and thumbnails do not render after the render delay, request `Enhanced GPU Rendering`. For accepted artists, file the request in your artist DM. For applying artists, file your request in the Art Blocks’ Discord Channel #artist-application-support. 
+If your piece takes a certain amount of time to render fully, you can type in the render delay to let the server know when to render your output’s thumbnails. This render time will be in milliseconds. If your algorithm is GPU intensive, and thumbnails do not render after the render delay, request `Enhanced GPU Rendering`. For accepted artists, file the request in your artist DM. For applying artists, file your request in the Art Blocks’ Discord Channel #artist-application-support.
 
 ### Display static (toggle)
 
@@ -94,6 +101,7 @@ If red, the project’s primary view will be dynamic; if blue, the project’s p
 For optimized performance, toggle `display static` if outputs are not animated, but take a long time to render.
 
 ### Project scripts ⛽📄
+
 Here, you will upload your project’s script. Your features script should be separate from your project script.
 
 Remember, tokenData.hash is a global variable in the environment this script will live in, so you do not need to define tokenData in your script, except your script will have access to it.
@@ -120,65 +128,106 @@ For many artists, the process for writing your features script will likely entai
 
 ## Minter:
 
-### MinterSuite ⛽📄
+!!!info
+For an overview of all minters available on Art Blocks, please see the [Minter Suite](minter-suite.md) page.
 
-The MinterSuite is an update to our broader smart-contract architecture at Art Blocks that allows artists to set specific minting contracts on a per-project basis.
+### Configuring Your Minter ⛽📄
 
-The MinterSuite currently includes the following minter options, which will continue to expand over time:
-**Set Price - ETH** is used for fixed price releases
+Go to the Minter tab within your shell and select the ‘minter for project’ drop-down menu. From that menu, select your desired MinterSuite option. [Please note that mint #0 will be created using the Set Price- ETH option.]
 
-**Automated Exponential Dutch Auction**: For exponential Dutch auctions, artists specify the starting price, ending price, and the half-life for price drops. 
+Once the desired minter is selected, you will be able to input and configure your minter's pricing and other relevant information, performing any necessary transactions along the way. For help determining pricing and configuration, please see the [Minting on Mainnet](#minting-on-mainnet) section below.
 
-**Dutch Auction with Settlement - Exponential Price Decrease**
+### Minting on Staging
 
-In this option, collectors will pay the price of the last mint. Collectors who purchase above this price will be able to claim a settlement after the auction which will be the difference between the price they purchased at and the last purchase price. What this means for artists is that you would claim your revenue after the project’s sell out/after the dutch auction duration in one transaction. The Dutch auction with settlement minter can be coupled with an allowlist minter. In this case, the allowlist must come before the dutch auction with settlement*.
+After you’ve uploaded your script and you’re ready to start minting, ensure your `minter` is set to `Set Price - ETH (V4)`. You’ll want to set your mint price at `.0` since you’re using Goerli ETH.
 
-*This minter employs a lot of game theory on the collector’s end. While all collectors will pay the resting price of the auction, we do not expect the overall revenue that artists receive to decrease between this option and the exponential Dutch auction without settlement. While we begin rolling this option out, we will continue to allow DAs without settlement, but we would like to move towards all DAs including settlement in the future. 
+### Minting on Mainnet
 
+This section provides an overview of how to configure your selected minters on mainnet. The Art Blocks team can assist and advise in determining the best type of minter and associated pricing parameters.
 
-**Automated Linear Dutch Auction**: For linear Dutch auctions, artists will specify the starting price, ending price, starting time, and ending time of the auction. The price will then gradually decrease each block over the total auction time.
+Based on your selected minter option, you will need to set your project price. The different pricing mechanics are outlined below.
 
-**Set price in custom ERC20**: Set price in ERC20 is a fixed price for your sale with a custom token. Artists will specify the address for the custom token sale. 
+!!!info
+Note that all current production minters support the ability to limit the number of mints on that specific minter for your project. This means that multiple minters may be used sequentially for a given project.
+!!!
 
-**Set Price - ETH, Allowlisted Users Only (V5)** is used for allowing only a predetermined list of wallet addresses to mint. These wallets can mint unlimited times until the project invocations limit is reached (if no mint limit was set) or as many times as they want until they reach the mint limit. 
+---
 
-Artists can choose the list of addresses to allow as well as the # of mints allowed per-wallet. Currently, artists are responsible for crafting their allowlist and uploading a comma-separated list of ETH addresses in a .txt or .CSV file to the artist dashboard. These wallet addresses cannot be ENS names, but list the full address of the wallet. [Premint](https://www.premint.xyz/) is a super helpful tool for creating an allowlist by using social channels to reach collectors, friends, family, etc. In addition, Art Blocks hosts a [Python script](https://github.com/ArtBlocks/artblocks-community-tooling/tree/main/SnapshotABHolders) for retrieving & snapshotting either a list of all Art Blocks token holders or the token-holders of a specific project.
+**Set Price Minters (ETH | ERC20)**
 
-Note that vault delegation via [Delegate Cash](https://delegate.cash/) is available for the Allowlisted Users minter. For more details please visit this [video walkthrough](https://www.youtube.com/watch?v=2-AgG--zcaw&list=PLSNTJAzmISeZcLm19EhafsGjJXwwgzBbU&index=5).
+The price to purchase a token is set by the artist and is the same for all purchasers.
 
-**Set Price - ETH, Token Holders Only (V4)** this minter allows its tokens to be minted with ETH when the purchaser owns an allowlisted ERC-721 NFT. This contract does NOT track if a purchaser has/has not minted already (ie. a "mint limit" is not available) -- it simply restricts purchasing to anybody that holds one or more of a specified list of ERC-721 NFTs.
+If using an ERC20 minter, the artist will need to specify the ERC20 token address for the custom token sale.
 
-Artists may use the artist dashboard to pre-select a list of allowlisted projects, of which any valid token holders will be able to purchase for the upcoming project. Note that a "snapshot" won't apply to this minter -- after the project's been made public, users can purchase a token from any allowlisted project and mint freely.
+---
 
-Note that vault delegation via [Delegate Cash](https://delegate.cash/) is available for the Token Holders Only minter. For more details please visit this [video walkthrough](https://www.youtube.com/watch?v=2-AgG--zcaw&list=PLSNTJAzmISeZcLm19EhafsGjJXwwgzBbU&index=5).
+**Automated Exponential Dutch Auction (with settlement | without settlement)**
 
-**[Artists on Staging]** After you’ve uploaded your script and you’re ready to start minting, ensure your `minter` is set to `Set Price - ETH (V2)`. You’ll want to set your mint price at `.0` since you’re using Goerli ETH. 
+!!!info
+In addition to the information below, please see the [Project Pricing: Dutch Auction Settings](https://docs.artblocks.io/creator-docs/creator-onboarding/readme/project-pricing-model/) section for more information on how to determine the appropriate pricing parameters for your auction.
+!!!
 
-### How to set your Project Price
+For exponential Dutch auctions, artists specify the `start time`, `starting price`, `ending price`, and `half-life` for price drops. These auction mechanisms aim to allow collectors to achieve price discovery on the blockchain.
 
-You may choose between the different pricing mechanics outlined below. The first step is to choose your desired selling option. The Art Blocks team can assist and advise in determining this.
+Half-life is the least intuitive of the parameters. One way to determine half-life is to think of the total duration of the auction and then work backward to find the half-life at that total time. . For example:
 
-### Different Project pricing mechanics. 
+- Consider Exponential Dutch auction was starting at 1 ETH and lowering to 0.1 ETH over 30 minutes.
+- Using [this calculator](https://www.calculator.net/half-life-calculator.html), the half-life can be determined to be 9 minutes (540 seconds). This means every 9 minutes, the price would gradually be cut in half. After 9 minutes, the auction will reach 0.5, and after 18 minutes, the auction will reach 0.25. The price drops within those half-life steps will gradually lower every block until the auction ends, at which point the auction will remain constant at the ending price.
 
-**Set Price - ETH** is used for fixed price releases
+One way to think of an exponential auction is that the rate of price _percent_ decrease is constant throughout the auction.
 
-**Automated Exponential Dutch Auction**: For exponential Dutch auctions, artists specify the starting price, ending price, and the half-life for price drops. An easier way to determine this is to think of the total duration of the auction and then work backward to find the half-life at that total time. This model allows collectors to decide the value of the work. For example, let's say that an Exponential Dutch auction was starting at 1 ETH and lowering to 0.1 ETH over 30 minutes. In this case, the half-life is 9 minutes. This means every 9 minutes, the price would gradually be cut in half. After 9 minutes, the auction will reach 0.5, and after 18 minutes, the auction will reach 0.25. The price drops within those half-life steps will gradually lower every block. You can use [this calculator] (https://www.calculator.net/half-life-calculator.html) to find your auction’s half-life: Please note that results from that calculator will need to be converted from minutes to seconds for Art Blocks. 
+!!!info Artist Instructions for Claiming Revenue (settlement minter only)
 
-**Automated Linear Dutch Auction**: For linear Dutch auctions, artists will specify the starting price, ending price, starting time, and ending time of the auction. The price will then gradually decrease each block over the total auction time.
+Artists are able to claim revenue after either:
 
-**Set price in custom ERC20**: Set price in ERC20 is a fixed price for your sale with a custom token. Artists will specify the address for the custom token sale. 
+- the project’s sell out, or
+- the dutch auction reaches resting price
 
-**Set Price - ETH, Allowlisted Users Only (V1)** these are addresses that are allowed to mint as many times as they want until they reach the mint limit (artists sets mint/wallet)
+We ask that artists promptly collect revenue when it becomes available. To collect revenue:
 
-### Input your pricing information
+- Click the `Claim Revenue` button that becomes available in your artist dashboard, wich will prompt you to send a transaction
+  - If the button is selected after the project has sold out, all revenue from the project will be distributed at the time of claim
+  - If the button is selected after the auction reaches resting price, but before all tokens have been sold, revenue from previous purchases will be transferred. Revenue from subsequent purchases at resting price will be distributed immediately at the time of of each purchse.
 
-Go to the Minter tab within your shell and select the ‘minter for project’ drop-down menu. From that menu, select your desired MinterSuite option. [Please note that mint #0 will be created using the Set Price- ETH option. If your project is sold via Dutch auction, please set the price to your auction’s resting price for mint #0. After mint #0, you may then adjust the MinterSuite back to your desired option.] Once the price option has been selected from the drop-down menu, select Submit. If you’re using a Dutch auction minter option, you will then enter the `start price in eth` and `base price in eth`.
+!!!
+
+---
+
+**Automated Linear Dutch Auction**
+
+!!!info
+In addition to the information below, please see the [Project Pricing: Dutch Auction Settings](https://docs.artblocks.io/creator-docs/creator-onboarding/readme/project-pricing-model/) section for more information on how to determine the appropriate pricing parameters for your auction.
+!!!
+
+For linear Dutch auctions, artists will specify the `starting time`, `starting price`, `ending price`, and `ending time` of the auction. The price will then linearly decrease each block over the total auction time.
+
+---
+
+**Set Price - ETH, Allowlisted Users Only**
+
+Pricing of tokens on this minter is only supported as a fixed price, in ETH.
+
+!!!info
+For details on how to create and upload an allowlist, please see the _Allowlisted Users Only_ portion of the [Minter Suite Overview](#minter-suite-overview-⛽📄) section above.
+!!!
+
+---
+
+**Set Price - ETH, Token Holders Only**
+
+Pricing of tokens on this minter is only supported as a fixed price, in ETH.
+
+!!!info
+For details on how to specify which token holders are allowed to mint your project, please see the _Token Holders Only_ portion of the [Minter Suite Overview](#minter-suite-overview-⛽📄) section above.
+!!!
+
+---
 
 ## Tags:
 
-Tags are labels you can assign to your project. Users can now filter collections based on the following tags: `animated,` `interactive,` `evolving,`  `audio,` and `responsive.`
+Tags are labels you can assign to your project. Users can now filter collections based on the following tags: `animated,` `interactive,` `evolving,` `audio,` and `responsive.`
 
-You may add tags to your project in  `edit project` on the `tags` button in your shell. If you’ve already released your work on Art Blocks, we encourage you to go in and add relevant tags to your project. 
+You may add tags to your project in `edit project` on the `tags` button in your shell. If you’ve already released your work on Art Blocks, we encourage you to go in and add relevant tags to your project.
 
 **animated** - moving image projects
 
@@ -190,32 +239,42 @@ You may add tags to your project in  `edit project` on the `tags` button in your
 
 **responsive** - project outputs scale to any screen size
 
-If you have a suggested tag for your project that you would like to be considered, please post your suggestions in Discord in #artist-general. 
+If you have a suggested tag for your project that you would like to be considered, please post your suggestions in Discord in #artist-general.
 
 ## Payout ⛽
+
 Projects with multiple artists can use the additional payee address field to split project payments between multiple wallets for primary and secondary sales. When a project only has one artist, the additional payee field is commonly used to manage on-chain charitable donations. The charity’s wallet can be entered in the additional payee field. The percentage entered in the additional payee field will then be directly transferred to the charity as sales are made.
 
-!!!danger Artists must propose changes to their payment addresses (and splits between primary/additional) for admin approval. Approval is granted before Mint #0!!!
+!!!danger
+Artists must propose changes to their payment addresses (and splits between primary/additional) for admin approval. Approval is granted before Mint #0
+!!!
 
 #### Revenue splits with multiple artists
+
 For projects with multiple artists, we recommend using [0xSplits](https://www.0xsplits.xyz/) to split revenue among the group. Instructions on how to create a Split can be found [here](https://www.youtube.com/watch?v=P_uqQJghNAo). Once you’ve created your Split, paste the address into the additional payee field. You can also include a charitable giving donation directly in the Split.
 
 #### Propose current artist address or add a new one
+
 This address will have access to edit the project in Art Blocks’ staging environment.
 
 #### Propose additional payee address for primary sales
-Input collaborator’s or charity wallet address here. 
+
+Input collaborator’s or charity wallet address here.
 
 #### Propose additional payee percentage for primary sales
+
 Payout percentages are at the artist’s discretion.
 
 #### Propose additional payee address for secondary sales
-Additional address that will receive a portion of secondary sales. 
+
+Additional address that will receive a portion of secondary sales.
 
 #### Propose additional payee percentage for primary sales
+
 The royalty field should be entered as a number and does not require a % symbol.
 
-#### Understanding secondary sales 
+#### Understanding secondary sales
+
 Secondary marketplaces can choose if they’d like to honor the secondary market royalty amount. Please note that OpenSea does not currently honor this field. On OpenSea, artists receive 5% of all secondary sales. Because of this, for consistency, we recommend setting your secondary market royalty to 5%. Note that all secondary details are for on-chain royalties, which OpenSea is not yet supporting (but we expect that will happen soon). For OpenSea royalties, Art Blocks will redistribute secondary sales monthly.
 
 To learn more about royalty distributions, see [here](faqs.md#how-does-royalty-distribution-work).
@@ -236,11 +295,11 @@ When it is time for your project to go live, you will press the “Unpause” bu
 
 ### Refresh Token Image
 
-This button will queue your token thumbnail to be refreshed. The refresh takes time to process fully. If a script update was successful, and `live views` are correct, but thumbnails haven’t refreshed, please clear your cache. If you have cleared your cache and are still not seeing the correct thumbnail view,a subgraph delay may be the reason. Stay updated on system operations at [status.artblocks.io] (status.artblocks.io). 
+This button will queue your token thumbnail to be refreshed. The refresh takes time to process fully. If a script update was successful, and `live views` are correct, but thumbnails haven’t refreshed, please clear your cache. If you have cleared your cache and are still not seeing the correct thumbnail view,a subgraph delay may be the reason. Stay updated on system operations at [status.artblocks.io] (status.artblocks.io).
 
 Rendering tokens does take computing power, of which we have a limited amount. Please feel free to refresh tokens after making updates, but note that if our rendering pipeline starts clogging up requests, we may have to consider rate-limiting refresh requests. In summary, use this button when testing out updates, but avoid spamming, or things will get jammed up.
 
-With this button, you can refresh per token. The Art BlocksTeam has the power to refresh all thumbnails in a project at once, and we are happy to do so for you. Request a batch refresh after updating your script in your artist DM. If you are still in the application queue, you may request a batch refresh in the #artist-application-support channel in Discord. 
+With this button, you can refresh per token. The Art BlocksTeam has the power to refresh all thumbnails in a project at once, and we are happy to do so for you. Request a batch refresh after updating your script in your artist DM. If you are still in the application queue, you may request a batch refresh in the #artist-application-support channel in Discord.
 
 ### Details
 

--- a/creator-onboarding/readme/project-form-fields-guide.md
+++ b/creator-onboarding/readme/project-form-fields-guide.md
@@ -164,7 +164,7 @@ If using an ERC20 minter, the artist will need to specify the ERC20 token addres
 **Automated Exponential Dutch Auction (with settlement | without settlement)**
 
 !!!info
-In addition to the information below, please see the [Project Pricing: Dutch Auction Settings](https://docs.artblocks.io/creator-docs/creator-onboarding/readme/project-pricing-model/) section for more information on how to determine the appropriate pricing parameters for your auction.
+In addition to the information below, please see the [Project Pricing: Dutch Auction Settings](project-pricing-model.md) section for more information on how to determine the appropriate pricing parameters for your auction.
 !!!
 
 For exponential Dutch auctions, artists specify the `start time`, `starting price`, `ending price`, and `half-life` for price drops. These auction mechanisms aim to allow collectors to achieve price discovery on the blockchain.
@@ -194,10 +194,6 @@ We ask that artists promptly collect revenue when it becomes available. To colle
 ---
 
 **Automated Linear Dutch Auction**
-
-!!!info
-In addition to the information below, please see the [Project Pricing: Dutch Auction Settings](https://docs.artblocks.io/creator-docs/creator-onboarding/readme/project-pricing-model/) section for more information on how to determine the appropriate pricing parameters for your auction.
-!!!
 
 For linear Dutch auctions, artists will specify the `starting time`, `starting price`, `ending price`, and `ending time` of the auction. The price will then linearly decrease each block over the total auction time.
 

--- a/creator-onboarding/readme/project-form-fields-guide.md
+++ b/creator-onboarding/readme/project-form-fields-guide.md
@@ -207,8 +207,15 @@ For linear Dutch auctions, artists will specify the `starting time`, `starting p
 
 Pricing of tokens on this minter is only supported as a fixed price, in ETH.
 
+To set up an allowlist for your project:
+
+1. Select `Set Price - ETH, Allowlisted Users Only`
+2. Upload your .csv or .txt file. See info box below for more details.
+3. Enter your fixed price
+4. We recommend leaving the mint per wallet limit to 1 for allowlist. If you would like to adjust this, please let the Art Blocks Team know.
+
 !!!info
-For details on how to create and upload an allowlist, please see the _Allowlisted Users Only_ portion of the [Minter Suite Overview](#minter-suite-overview-⛽📄) section above.
+Artists are responsible for crafting their allowlist and uploading a comma-separated list of ETH addresses in a .txt or .CSV file to the artist dashboard. These wallet addresses cannot be ENS names, but list the full address of the wallet. [Premint](https://www.premint.xyz/) is a super helpful tool for creating an allowlist by using social channels to reach collectors, friends, family, etc. In addition, Art Blocks hosts a [Python script](https://github.com/ArtBlocks/artblocks-community-tooling/tree/main/SnapshotABHolders) for retrieving & snapshotting either a list of all Art Blocks token holders or the token-holders of a specific project.
 !!!
 
 ---
@@ -217,9 +224,7 @@ For details on how to create and upload an allowlist, please see the _Allowliste
 
 Pricing of tokens on this minter is only supported as a fixed price, in ETH.
 
-!!!info
-For details on how to specify which token holders are allowed to mint your project, please see the _Token Holders Only_ portion of the [Minter Suite Overview](#minter-suite-overview-⛽📄) section above.
-!!!
+Artists may use the artist dashboard to pre-select a list of allowlisted Art Blocks or Art Blocks Engine projects, of which any valid token holders will be able to purchase for the upcoming project. Note that a "snapshot" won't apply to this minter -- after the project has been made public, users can purchase a token from any allowlisted project and mint freely.
 
 ---
 


### PR DESCRIPTION
Update how minter-related documentation is organized in our docs.

This update adds a minter-suite page to our docs, and intends to make our documentation surrounding the minter suite easier to understand, and more up to date.

Summary of changes:
- The checklists (presents and curated) now point to the new `minter-suite.md` overview page and the "Configuring Your Minter" section of `project-form-fields-guide.md`
- The new `minter-suite.md` gives an overview of each minter, focused on explaining what the minter does, and why an artist might choose to use it
- The "Minter" section points to `minter-suite.md` as the place to look for an overview of the minters, and the "Configuring Your Minter" and "Minting on Mainnet" sections focus on the details related to configuring each specific minter
  - In general, this section is intended to be more helpful _after_ an artist has selected one or minters from the `minter-suite.md` overview, and is ready to configure the minter for their project.
  - The DA minters point to the really great `project-pricing-model.md` page as a reference for DA resting price values.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204138936906076