### PR TITLE
Update documentation path for public contracts monorepo

### DIFF
--- a/art-blocks-engine-onboarding/art-blocks-engine-101/Engine-partner-onboarding-steps.md
+++ b/art-blocks-engine-onboarding/art-blocks-engine-101/Engine-partner-onboarding-steps.md
@@ -7,7 +7,7 @@ An overview of the steps required to onboard as an Art Blocks Engine partner.
 
 ## 1. Initial outreach
 
-Interested in using Art Blocks Engine to launch a generative content platform? 
+Interested in using Art Blocks Engine to launch a generative content platform?
 
 Reach out to **info@artblocks.io** to get started. We'll discuss your needs, explain what we offer in a partnership, and align expectations.
 
@@ -33,13 +33,13 @@ To get started, you'll provide our team with:
 - The name you’ll use for tokens from your contract (e.g., for Art Blocks, it is "Art Blocks")
 - The ticker symbol you’ll use for tokens from your contract (e.g., for Art Blocks, it is "BLOCKS")
 - Deployment Type: V3 Engine or V3 Engine Flex
-- [Minter Type](https://github.com/ArtBlocks/artblocks-contracts/blob/main/MINTER_SUITE.md#minter-suite-documentation): flat price eth only, set price custom erc20, merkle tree allowlist, holder-gated, linear DA, exponential DA, and exponential DA with settlement
+- [Minter Type](https://github.com/ArtBlocks/artblocks-contracts/blob/main/packages/contracts/MINTER_SUITE.md#minter-suite-documentation): flat price eth only, set price custom erc20, merkle tree allowlist, holder-gated, linear DA, exponential DA, and exponential DA with settlement
 - Starting project ID # (>=0):
 - Set autoApproveArtistSplitProposals: true or false
 
-Regarding "autoApproveArtistSplitProposals" - It needs to be set at deployment and cannot be changed later. 
+Regarding "autoApproveArtistSplitProposals" - It needs to be set at deployment and cannot be changed later.
 
-tldr - if true, artist royalty wallet changes are auto-approved. If false, the contract admin will need to approve the artist's royalty wallet changes. This is an added check to ensure your artists aren't changing royalty wallets to a random address, which could complicate accounting/ OFAC compliance. 
+tldr - if true, artist royalty wallet changes are auto-approved. If false, the contract admin will need to approve the artist's royalty wallet changes. This is an added check to ensure your artists aren't changing royalty wallets to a random address, which could complicate accounting/ OFAC compliance.
 
 Note: We cannot deploy your contract until you provide the above information. **The name and symbol tied to your contract cannot change once it’s deployed.**_
 
@@ -47,7 +47,7 @@ Note: We cannot deploy your contract until you provide the above information. **
 
 ## 5. Contract configuration & testnet deployment
 
-We will configure your smart contract before transferring ownership to Ethereum address provided in Step 4. Once we deploy your contract on the test network, you can start testing your generative script. 
+We will configure your smart contract before transferring ownership to Ethereum address provided in Step 4. Once we deploy your contract on the test network, you can start testing your generative script.
 
 [!badge Timeline: 1 week]
 
@@ -55,7 +55,7 @@ We will configure your smart contract before transferring ownership to Ethereum 
 
 Art Blocks will integrate your contracts with our rendering infrastructure and provide access to our staging website for you to perform project onboarding and configuration via the Art Blocks site on the test network.
 
-Contracts are deployed twice per month and typically take 1 week to complete and transfer. 
+Contracts are deployed twice per month and typically take 1 week to complete and transfer.
 
 [!badge Timeline: 1 week]
 
@@ -73,9 +73,9 @@ Your team ensures the minting process is working on the test network by minting 
 [!badge Timeline: weeks-months (depends on partner)]
 - [x] Mint test outputs
 - [x] Test drop mechanic (flat price, Dutch Auction, whitelists, etc.)
-- [x] Test purchase with custom ERC20 (if applicable) 
+- [x] Test purchase with custom ERC20 (if applicable)
 - [x] Request a script audit from Art Blocks
-- [x] Test your script across different hardware/software ([browserstack.com](https://www.browserstack.com/)) 
+- [x] Test your script across different hardware/software ([browserstack.com](https://www.browserstack.com/))
 - [x] Let the Art Blocks team know testing is complete and you're ready for a mainnet deployment
 
 ## 9. Deployment to mainnet
@@ -89,8 +89,8 @@ Art Blocks deploys the mainnet version of your contract and integrates it with o
 Your team integrates the mainnet contract with your site and prepares to generate your first NFT (mint #0)
 
 [!badge Timeline: Depends on partner]
-- [x] Connect your front end with the *new* mainnet contracts, using the same minting mechanics from testnet (drop type & currency) 
-- [x] Mint #0 from your front end 
+- [x] Connect your front end with the *new* mainnet contracts, using the same minting mechanics from testnet (drop type & currency)
+- [x] Mint #0 from your front end
 
 
 ## 11. Mint #0
@@ -99,14 +99,14 @@ You can mint your project's first official token via your site!
 
 ## 12. Set secondary royalties
 
-Art Blocks will set *our* secondary royalty before we transfer contract ownership, but you are responsible for setting your own secondary royalty across all secondary marketplaces. 
+Art Blocks will set *our* secondary royalty before we transfer contract ownership, but you are responsible for setting your own secondary royalty across all secondary marketplaces.
 
-OpenSea - https://docs.opensea.io/docs/10-setting-fees-on-secondary-sales  
-LooksRare - https://docs.looksrare.org/guides/collection-management/set-or-edit-collection-royalties  
-x2y2 - https://docs.x2y2.io/guides/collection-management/manage-your-collection  
+OpenSea - https://docs.opensea.io/docs/10-setting-fees-on-secondary-sales
+LooksRare - https://docs.looksrare.org/guides/collection-management/set-or-edit-collection-royalties
+x2y2 - https://docs.x2y2.io/guides/collection-management/manage-your-collection
 
-Note: The vast majority of secondary activity takes place on OpenSea. Currently, OpenSea does not recognize on-chain roylaties and needs to be set through their interface. However, they plan to recognize [Roylaty Registry](https://royaltyregistry.xyz/lookup) in the near-ish future. We highly encourage you to sign up for the Royalty Registry to avoid missed secondary roylaties. 
-  
+Note: The vast majority of secondary activity takes place on OpenSea. Currently, OpenSea does not recognize on-chain roylaties and needs to be set through their interface. However, they plan to recognize [Roylaty Registry](https://royaltyregistry.xyz/lookup) in the near-ish future. We highly encourage you to sign up for the Royalty Registry to avoid missed secondary roylaties.
+
 Instructions on setting up Royalty Registry - https://docs.artblocks.io/creator-docs/art-blocks-engine-onboarding/art-blocks-engine-101/engine-royalty-registry-setup/
 
 

--- a/art-blocks-engine-onboarding/art-blocks-engine-101/Engine-technical-details.md
+++ b/art-blocks-engine-onboarding/art-blocks-engine-101/Engine-technical-details.md
@@ -2,8 +2,8 @@
 
 This page goes deeper into some technical considerations when working with the most current version of Artblocks Engine Flex.
 The latest version of the Engine Flex contract (v3) and interface can be found here:
-- https://github.com/ArtBlocks/artblocks-contracts/blob/main/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
-- https://github.com/ArtBlocks/artblocks-contracts/blob/main/contracts/interfaces/0.8.x/IGenArt721CoreContractV3_Engine_Flex.sol
+- https://github.com/ArtBlocks/artblocks-contracts/blob/main/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol
+- https://github.com/ArtBlocks/artblocks-contracts/blob/main/packages/contracts/contracts/interfaces/0.8.x/IGenArt721CoreContractV3_Engine_Flex.sol
 
 ## Introduction To External Asset Dependencies
 
@@ -15,7 +15,7 @@ struct ExternalAssetDependency {
 }
 ```
 
-The Engine Flex contract introduces the concept of external asset dependencies. These essentially function as on-chain pointers to off-chain assets stored using decentralized storage technologies and, with the latest version of flex, also supports fully on-chain data storage. An external asset dependency is comprised of its content identifier (CID), if it's using Arweave or IPFS, a bytecodeAddress if it's specifically dealing with fully on-chain data, and a dependencyType, which maps to an Engine Flex supported platform. 
+The Engine Flex contract introduces the concept of external asset dependencies. These essentially function as on-chain pointers to off-chain assets stored using decentralized storage technologies and, with the latest version of flex, also supports fully on-chain data storage. An external asset dependency is comprised of its content identifier (CID), if it's using Arweave or IPFS, a bytecodeAddress if it's specifically dealing with fully on-chain data, and a dependencyType, which maps to an Engine Flex supported platform.
 
 Engine Flex currently supports adding external asset dependencies of the following types:
 - IPFS
@@ -35,7 +35,7 @@ Note the parameter `_cidOrData`, which allows you to either pass in a CID if you
 
 For convenience and utility, the contract also provides the following function, allowing you to easily grab a project's external asset dependency at a specific index:
 ```solidity
-function projectExternalAssetDependencyByIndex(uint256 _projectId, uint256 _index) 
+function projectExternalAssetDependencyByIndex(uint256 _projectId, uint256 _index)
 ```
 This convenience function returns data in the form of the following format:
 ```solidity
@@ -54,13 +54,13 @@ Note that for dependencyTypes other than onchain (IPFS, Arweave), the returned b
 
 Some important factors to keep in mind with the above functions:
 - Only allowlisted/artist addresses can call these.
-- `ExternalAssetDependencyType _dependencyType` is a solidity enum, which can be passed into these functions as a uint8. This enum only defines three options as of now, `IPFS`,`ARWEAVE`, and `ONCHAIN`, which can be represented as `0`,`1`, and `2` respectively. 
+- `ExternalAssetDependencyType _dependencyType` is a solidity enum, which can be passed into these functions as a uint8. This enum only defines three options as of now, `IPFS`,`ARWEAVE`, and `ONCHAIN`, which can be represented as `0`,`1`, and `2` respectively.
 
 ### Note On Removing External Asset Dependencies
- 
+
 In the interest of saving gas, the `removeProjectExternalAssetDependency()` function is implemented in such a way that it does not preserve the order of the project's external asset dependency mapping. Specifically, the way this removal logic works is as follows: when an index to remove is passed in, the element at that index being removed is swapped with the element at the last index of the list of assets. Now that the last index holds the element to be removed, that element is removed off the list. This method, in addition to being more gas efficient, also ensures that our list/mapping does not have any "holes". The tradeoff, however, is that the removal causes the order of the external asset dependencies in this list to change, albeit in a deterministic manner: the element at the last index always moves to the removed index. This is important to keep in mind when writing your project script, though you can always update the ordering manually as you see fit by utilizing the `updateProjectExternalAssetDependency()` function.
 
-You can view directly the full implementation of this removal function here: https://github.com/ArtBlocks/artblocks-contracts/blob/main/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol#L524
+You can view directly the full implementation of this removal function here: https://github.com/ArtBlocks/artblocks-contracts/blob/main/packages/contracts/contracts/engine/V3/GenArt721CoreV3_Engine_Flex.sol#L524
 
 ## Preferred Gateways
 
@@ -69,7 +69,7 @@ string public preferredIPFSGateway;
 string public preferredArweaveGateway;
 ```
 
-The Engine Flex contract allows you to specify preferred gateways for the currently supported dependency types (IPFS & Arweave). Gateways are accessible HTTP interfaces and, when combined with an asset CID, expose urls for assets being stored on these off-chain decentralized platforms. These preferred gateways are updateable with a string param via the following functions: `updateArweaveGateway()` & `updateIPFSGateway()`.       
+The Engine Flex contract allows you to specify preferred gateways for the currently supported dependency types (IPFS & Arweave). Gateways are accessible HTTP interfaces and, when combined with an asset CID, expose urls for assets being stored on these off-chain decentralized platforms. These preferred gateways are updateable with a string param via the following functions: `updateArweaveGateway()` & `updateIPFSGateway()`.
 
 Please note that these preferred gateways are set per-contract, not per-project.
 
@@ -105,7 +105,7 @@ If you are specifically looking to utilize an IPFS/ARWEAVE type external asset d
 ```js
 (async () => {
         await import('JS_EXTERNAL_ASSET_DEPENDENCY_FULL_URL_GOES_HERE');
-    
+
         // project script follows below
 })()
 ```
@@ -120,7 +120,7 @@ function loadScript(url, callback)
    script.type = 'text/javascript';
    script.src = url;
 
-   // then bind the event to the callback function 
+   // then bind the event to the callback function
    // there are several events for cross browser compatibility
    script.onreadystatechange = callback;
    script.onload = callback;

--- a/art-blocks-engine-onboarding/art-blocks-engine-101/what is Art Blocks Engine.md
+++ b/art-blocks-engine-onboarding/art-blocks-engine-101/what is Art Blocks Engine.md
@@ -2,7 +2,7 @@
 order: 1000
 ---
 # What is Art Blocks Engine and Engine Flex?
-Art Blocks Engine and Engine Flex are custom branded solutions from Art Blocks. Our offerings allow the generative NFT minting technology used by artists at Art Blocks to be integrated with third-party sites. 
+Art Blocks Engine and Engine Flex are custom branded solutions from Art Blocks. Our offerings allow the generative NFT minting technology used by artists at Art Blocks to be integrated with third-party sites.
 
 Engine allows partners to release generative outputs using our existing smart contracts and rendering infrastructure resulting in turnkey and branded generative projects. Engine partners own their smart contracts and can use them to release as many projects as they like as often as they like.
 
@@ -22,7 +22,7 @@ With Art Blocks Engine Flex contracts, a per-project (as opposed to per-contract
 
 Currently, we do not yet support the turnkey ability to programically upload/pin these dependencies to IPFS/Arweave within the Engine experience directly; however, our team is more than happy to assist partners in the process of uploading/pinning assets on IPFS/Arweave using existing third party solutions for doing so (e.g. Pinata in the case of IPFS).
 
-Note that for a single project, it is possible to have a single off-chain dependency (e.g. a single image file) or a set of off-chain dependencies (e.g. a series of images from a set). This means that is possible, for example, to have a project that creates 1of1ofX generative variants of a single base image asset, or one in which for a given token a random image is selected from the base image asset set, and then a generative process is applied to it. 
+Note that for a single project, it is possible to have a single off-chain dependency (e.g. a single image file) or a set of off-chain dependencies (e.g. a series of images from a set). This means that is possible, for example, to have a project that creates 1of1ofX generative variants of a single base image asset, or one in which for a given token a random image is selected from the base image asset set, and then a generative process is applied to it.
 
 It is also important to note that images are not the only supported external asset dependency type. It is possible to reference any file type that can be pinned/uploaded to IPFS or Arweave and intelligbly incorporated into a generative algorithm to create interesting artistic outputs. For example, a project could use `tensorflow.js` as its single-depedency, have its generative script be a tensorflow based creative coding algorithm, and store the model file for the machine learning model on IPFS or Arweave to support a ML/AI based project.
 
@@ -43,11 +43,11 @@ Both core contracts integrate with various peripheral contracts to provide flexi
 
 Partners should choose between the V3 Engine core contract and the V3 Engine Flex core contract based on their project's goals and technical capabilities. The smart contract architecture for Art Blocks Engine provides a robust and flexible system for managing and creating generative NFTs while integrating with various peripheral contracts to extend its capabilities.
 
-For additional context, please check out [this architecture overview (with accompanying diagrams)](https://github.com/ArtBlocks/artblocks-contracts/blob/main/V3_ARCHITECTURE.md).
+For additional context, please check out [this architecture overview (with accompanying diagrams)](https://github.com/ArtBlocks/artblocks-contracts/blob/main/packages/contracts/V3_ARCHITECTURE.md).
 
 ## What is the "minter suite"?
 
-The Art Blocks minter suite is a collection of smart contracts that facilitate the secure and efficient minting of generative art tokens for Engine contracts in the V3 architecture. 
+The Art Blocks minter suite is a collection of smart contracts that facilitate the secure and efficient minting of generative art tokens for Engine contracts in the V3 architecture.
 
 A summary of the division of responsibilities between the MinterFilter and individual Minters can be summarized as:
 
@@ -64,18 +64,18 @@ A summary of the division of responsibilities between the MinterFilter and indiv
 
 tl;dr: The MinterFilter serves as a control layer that ensures the correct minter is used for each project, while Minters handle token purchase processes and project-specific settings. This division of responsibilities enables a secure, efficient, and flexible set of contracts that we call the "minter suite".
 
-For additional context, please check out [this architecture overview (with accompanying diagrams)](https://github.com/ArtBlocks/artblocks-contracts/blob/main/MINTER_SUITE.md).
+For additional context, please check out [this architecture overview (with accompanying diagrams)](https://github.com/ArtBlocks/artblocks-contracts/blob/main/packages/contracts/MINTER_SUITE.md).
 
 ## What is generative art?
 
-Generative art is about developing systems that define rules for creating art. By introducing randomness to those systems, core concepts are expressed through unique outputs. In a contemporary sense, this means writing computer algorithms to define the system and introduce randomness, which allows for conceptual exploration and rapid iteration. 
+Generative art is about developing systems that define rules for creating art. By introducing randomness to those systems, core concepts are expressed through unique outputs. In a contemporary sense, this means writing computer algorithms to define the system and introduce randomness, which allows for conceptual exploration and rapid iteration.
 
-Creative coders write scripts with specific parameters that introduce and explore features, which generate the final outputs in a collection. With Art Blocks’ generative minting technology, collectors participate in the creation of the art. No one knows exactly what a piece will look like before it's minted, not even the artist. Each NFT is generated at the time of purchase using the buyer’s unique transaction hash to create a ‘1 of 1 of X’, which adds an extra layer of magic as the creator and collector watch a project come alive. 
+Creative coders write scripts with specific parameters that introduce and explore features, which generate the final outputs in a collection. With Art Blocks’ generative minting technology, collectors participate in the creation of the art. No one knows exactly what a piece will look like before it's minted, not even the artist. Each NFT is generated at the time of purchase using the buyer’s unique transaction hash to create a ‘1 of 1 of X’, which adds an extra layer of magic as the creator and collector watch a project come alive.
 
 The interesting part of modern generative art is that it involves working in series - often a large series. So instead of pursuing a single compelling work of art, a generative artist creates an algorithm capable of tens, hundreds, or thousands of compelling works of art. Which, when taken as a whole, expresses the range of possibilities contained in a single algorithm.
 
-## What are NFTs? 
-Nonfungible tokens (NFT) are unique digital assets stored on blockchain technology that can represent any digital or physical asset. 
+## What are NFTs?
+Nonfungible tokens (NFT) are unique digital assets stored on blockchain technology that can represent any digital or physical asset.
 
 ## On-chain vs. off-chain
 Art Blocks Engine enables creators to immutably store their generative NFT directly on the Ethereum blockchain (on-chain) or reference an external library or asset (off-chain). For an off-chain implimentation, partners can reference external off-chain assets using decentralized storage solutions like IPFS.
@@ -84,21 +84,21 @@ Decentralized and fully on-chain content is the most durable digital asset avail
 
 So, if Art Blocks ever shut down, all on-chain work would still be accessible since it's stored on the decentralized Ethereum blockchain and able to be viewed, bought, sold, and transferred without involving Art Blocks at all.
 
-In contrast, if we store generative algorithms on an Art Blocks-owned database, the NFTs would rely on Art Blocks to return the assets - and if we go offline, the assets would not be retrievable. Similarly, if a script is stored on-chain but uses data from off-chain sources, it's vulnerable to the host of that off-chain data going offline. 
+In contrast, if we store generative algorithms on an Art Blocks-owned database, the NFTs would rely on Art Blocks to return the assets - and if we go offline, the assets would not be retrievable. Similarly, if a script is stored on-chain but uses data from off-chain sources, it's vulnerable to the host of that off-chain data going offline.
 
-Off-chain NFTs rely on assets stored on external servers. There are many reasons to reference off-chain assets - data storage is expensive on Ethereum, and using external assets can reduce the cost of putting data on-chain. It also allows for interesting applications of generative art using external assets. However, if your NFT references external sources and those sources go offline, the NFT will only track ownership of unretrievable data.  
+Off-chain NFTs rely on assets stored on external servers. There are many reasons to reference off-chain assets - data storage is expensive on Ethereum, and using external assets can reduce the cost of putting data on-chain. It also allows for interesting applications of generative art using external assets. However, if your NFT references external sources and those sources go offline, the NFT will only track ownership of unretrievable data.
 
 For this reason, we only allow certain external libraries to be used in project scripts given their general recognition as extremely reliable file storage sources.
 
-Art Blocks Engine offers on-chain and off-chain solutions with our generative NFT minting technology. Which one is right for you depends on your project’s goals and technical capabilities. 
+Art Blocks Engine offers on-chain and off-chain solutions with our generative NFT minting technology. Which one is right for you depends on your project’s goals and technical capabilities.
 
 ## Creating durable digital assets
 Creating on-chain generative NFTs ensures your collectors can expect their digital assets to stay the same forever. But if you choose to launch a generative project with off-chain assets, there are ways to mitigate the risk of going off-line using technology like IPFS or Arweave. We’re happy to chat about the right Art Blocks Engine implementation for your next project.
 
 ## Potential use-cases
-The landscape of on-demand generative content has plenty of room to experiment. Some of our current partners include artists, galleries, art houses, online publications, and game developers. If you’re exploring an interesting project, get in touch, and let’s build together. 
+The landscape of on-demand generative content has plenty of room to experiment. Some of our current partners include artists, galleries, art houses, online publications, and game developers. If you’re exploring an interesting project, get in touch, and let’s build together.
 
-Current and upcoming use cases: 
+Current and upcoming use cases:
 
 - Fashion
 - Premier Artists


### PR DESCRIPTION
This PR fixes documentation links so they point to the correct location as a followup to this PR in the artblocks-contracts repo: https://github.com/ArtBlocks/artblocks-contracts/pull/697