### PR TITLE
Deprecated minter-specific fields

### DIFF
--- a/art-blocks-api/entities.md
+++ b/art-blocks-api/entities.md
@@ -112,12 +112,12 @@ Description: get specific details on the pay flow for a specified artist
 | createdAt                               | BigInt!  | When address initiated                                            |
 
 # EngineRegistry
-Description: Get specific details on the Art Blocks Engine registry. At this time, this is used largely for indexing purposes of V3_Engine* contracts only.
-| Field                               | Type                           | Description                                                                                                                     |
+
+Description: Get specific details on the Art Blocks Engine registry. At this time, this is used largely for indexing purposes of V3_Engine\* contracts only.
+| Field | Type | Description |
 | ----------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
 | id | ID! | Unique identifier made up of the Engine Registry's contract address |
 | registeredContracts | [Contract!] | Core contracts that are registered on this Engine Registry, when this is most recent Engine Registry to add the contract |
-
 
 # Contract
 
@@ -178,12 +178,12 @@ Description: get specific information about an account
 
 Description: get project account information
 
-| Field   | Type     | Description                    |
-| ------- | -------- | ------------------------------ |
-| id      | ID!      | Unique identifier token id     |
-| account | Account! | Account associated to project  |
-| project | Project! | Name of project                |
-| count   | Int!     | Total count of the project     |
+| Field   | Type     | Description                   |
+| ------- | -------- | ----------------------------- |
+| id      | ID!      | Unique identifier token id    |
+| account | Account! | Account associated to project |
+| project | Project! | Name of project               |
+| count   | Int!     | Total count of the project    |
 
 # Token
 
@@ -222,37 +222,37 @@ Description: get details about minters on a project
 
 Description: get details about mint on a project
 
-| Field                         | Type          | Description                                                              |
-| ----------------------------- | ------------- | ------------------------------------------------------------------------ |
-| id                            | ID!           | Unique identifier made up of minter contract address                     |
-| type                          | MinterType!   | Minter type                                                              |
-| minterFilter                  | MinterFilter! | Associated Minter Filter                                                 |
-| minimumAuctionLengthInSeconds | BigInt        | Minimum allowed auction length in seconds (linear Dutch auction minters) |
-| minimumHalfLifeInSeconds      | BigInt        | Minimum allowed half life in seconds (exponential Dutch auction minters) |
-| maximumHalfLifeInSeconds      | BigInt        | Maximum allowed half life in seconds (exponential Dutch auction minters) |
-| extraMinterDetails            | String!       | Configuration details used by specific minters (json string)             |
-| coreContract                  | Contract!     | Associated core contract                                                 |
-| updatedAt                     | BigInt!       | When the minter updated                                                  |
+| Field                         | Type          | Description                                                                                                                                       |
+| ----------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| id                            | ID!           | Unique identifier made up of minter contract address                                                                                              |
+| type                          | MinterType!   | Minter type                                                                                                                                       |
+| minterFilter                  | MinterFilter! | Associated Minter Filter                                                                                                                          |
+| minimumAuctionLengthInSeconds | BigInt        | Deprecated, use `extraMinterDetails[minimumAuctionLengthInSeconds]`.<br> Minimum allowed auction length in seconds (linear Dutch auction minters) |
+| minimumHalfLifeInSeconds      | BigInt        | Deprecated, use `extraMinterDetails[minimumHalfLifeInSeconds]`.<br> Minimum allowed half life in seconds (exponential Dutch auction minters)      |
+| maximumHalfLifeInSeconds      | BigInt        | Deprecated, use `extraMinterDetails[maximumHalfLifeInSeconds]`.<br> Maximum allowed half life in seconds (exponential Dutch auction minters)      |
+| extraMinterDetails            | String!       | Configuration details used by specific minters (json string)                                                                                      |
+| coreContract                  | Contract!     | Associated core contract                                                                                                                          |
+| updatedAt                     | BigInt!       | When the minter updated                                                                                                                           |
 
 # ProjectMinterConfiguration
 
 Description: get details of a specific mint
 
-| Field              | Type     | Description                                                                        |
-| ------------------ | -------- | ---------------------------------------------------------------------------------- |
-| id                 | ID!      | Unique identifier made up of minter contract address-projectId                     |
-| project            | Project! | The associated project                                                             |
-| minter             | Minter!  | The associated minter                                                              |
-| priceIsConfigured  | Boolean! | true if project's token price has been configured on minter                        |
-| currencySymbol     | String!  | currency symbol as defined on minter - ETH reserved for ether                      |
-| currencyAddress    | Bytes!   | currency address as defined on minter - address(0) reserved for ether              |
-| purchaseToDisabled | Boolean! | Defines if purchasing token to another is allowed                                  |
-| basePrice          | BigInt   | price of token or resting price of Duch auction, in wei                            |
-| startPrice         | BigInt   | Dutch auction start price, in wei                                                  |
-| halfLifeSeconds    | BigInt   | Half life for exponential decay Dutch auction, in seconds                          |
-| startTime          | BigInt   | Dutch auction start time (unix timestamp)                                          |
-| endTime            | BigInt   | Linear Dutch auction end time (unix timestamp)                                     |
-| extraMinterDetails | String!  | Configuration details used by specific minter project configurations (json string) |
+| Field              | Type     | Description                                                                                                          |
+| ------------------ | -------- | -------------------------------------------------------------------------------------------------------------------- |
+| id                 | ID!      | Unique identifier made up of minter contract address-projectId                                                       |
+| project            | Project! | The associated project                                                                                               |
+| minter             | Minter!  | The associated minter                                                                                                |
+| priceIsConfigured  | Boolean! | true if project's token price has been configured on minter                                                          |
+| currencySymbol     | String!  | currency symbol as defined on minter - ETH reserved for ether                                                        |
+| currencyAddress    | Bytes!   | currency address as defined on minter - address(0) reserved for ether                                                |
+| purchaseToDisabled | Boolean! | Defines if purchasing token to another is allowed                                                                    |
+| basePrice          | BigInt   | price of token or resting price of Duch auction, in wei                                                              |
+| startPrice         | BigInt   | Deprecated, use `extraMinterDetails[startPrice]`.<br> Dutch auction start price, in wei                              |
+| halfLifeSeconds    | BigInt   | Deprecated, use `extraMinterDetails[halfLifeSeconds]`.<br> Half life for exponential decay Dutch auction, in seconds |
+| startTime          | BigInt   | Deprecated, use `extraMinterDetails[startTime]`.<br> Dutch auction start time (unix timestamp)                       |
+| endTime            | BigInt   | Deprecated, use `extraMinterDetails[endTime]`.<br> Linear Dutch auction end time (unix timestamp)                    |
+| extraMinterDetails | String!  | Configuration details used by specific minter project configurations (json string)                                   |
 
 # Payment
 
@@ -370,7 +370,6 @@ Description: information about an additional CDN for a dependency
 # DependencyAdditionalRepository
 
 Description: information about an additional repository for a dependency
-
 
 | Field      | Type                       | Description                                          |
 | ---------- | -------------------------- | ---------------------------------------------------- |


### PR DESCRIPTION
Update subgraph entities docs tagging minter-specific fields as deprecated.

The following fields are deprecated, and will be replaced by keys of the same name in the extraMinterDetails json fields on the Minter and ProjectMinterConfiguration entities.

Minter
- minimumAuctionLengthInSeconds
- minimumHalfLifeInSeconds
- maximumHalfLifeInSeconds

ProjectMinterConfiguration
- startPrice
- halfLifeSeconds
- startTime
- endTime

## Partner impacts

This change is expected to have a minimal impact on Engine partners (as their minter suites are not currently indexed in the subgraph). However, Cc @ABDruid @cooper-temple for awareness 🙏 

## Follow-on
Eventually, the deprecated fields will be removed. This is expected to happen in a few weeks.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204310886205037