### PR TITLE
Update to latest retype release

### DIFF
--- a/.github/workflows/retype-action.yml
+++ b/.github/workflows/retype-action.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: retypeapp/action-build@v2
+      - uses: retypeapp/action-build@latest
         with:
           license: ${{ secrets.RETYPE_SECRET }}
 
-      - uses: retypeapp/action-github-pages@v2
+      - uses: retypeapp/action-github-pages@latest
         with:
           update-branch: true


### PR DESCRIPTION
This change will update the build action to pull the latest release when building.

New Retype [v3.0](https://retype.com/roadmap/#v3-0-0) major release.

Everything appears to be working great and there are no breaking changes with the v3.0 release.

You can easily test locally by [installing](https://retype.com/guides/getting-started/) Retype and run the command `retype start`.
