### PR TITLE
formatting bug

### DIFF
--- a/creator-onboarding/readme/project-form-fields-guide.md
+++ b/creator-onboarding/readme/project-form-fields-guide.md
@@ -96,9 +96,9 @@ If your piece takes a certain amount of time to render fully, you can type in th
 
 ### Canvas Mode (toggle) 📄
 
-If checked, data is directly pulled from the <canvas> element using `.toDataURL()` when producing static image renders. This additional rendering mode can be leveraged for projects with varying aspect ratios across different tokens.
+If checked, data is directly pulled from the `Canvas` element using `.toDataURL()` when producing static image renders. This additional rendering mode can be leveraged for projects with varying aspect ratios across different tokens.
 
-Please note that scripts containing multiple <canvas> elements may not render as intended.
+Please note that scripts containing multiple `Canvas` elements may not render as intended.
 
 ### Generate MP4 assets (toggle) 📄
 


### PR DESCRIPTION
Using carrot brackets (<) creates HTML elements in markdown so I switched this to code annotation instead.

Bug:
<img width="777" alt="Screen Shot 2023-06-08 at 1 55 09 PM" src="https://github.com/ArtBlocks/artblocks-docs/assets/52679312/b17f7807-2d9f-46d0-9b62-21ac28936580">
