### PR TITLE
docs: fix typos

### DIFF
--- a/art-blocks-engine-onboarding/art-blocks-engine-101/Engine-royalty-registry-setup-(V2-only).md
+++ b/art-blocks-engine-onboarding/art-blocks-engine-101/Engine-royalty-registry-setup-(V2-only).md
@@ -24,7 +24,7 @@ For Engine contracts, the following addresses may receive royalties:
 | ---------------------------- | -------------------------------------------------------------- |
 | Platform (Engine Partner)    | default 2.5%                                                   |
 | Render Provider (Art Blocks) | default 2.5%                                                   |
-| Artist                       | typically 5%, but configureable by artist                      |
+| Artist                       | typically 5%, but configurable by artist                      |
 | Additional Payee             | split between Artist & Additional Payee varies across projects |
 
 ## Configuring Royalties

--- a/art-blocks-engine-onboarding/art-blocks-engine-101/faqs.md
+++ b/art-blocks-engine-onboarding/art-blocks-engine-101/faqs.md
@@ -76,7 +76,7 @@ Contact your account manager for an invite link to the private Discord server.
 
 ## How long will the process take from start to public launch?
 
-The process typically takes 10 weeks from initial conversation to public launch, but is **highly** dependant on partner's resource allocation. To reduce delays, have a front-end developer, artist, go-to-market strategy, and sufficient onboarding time ready. 
+The process typically takes 10 weeks from initial conversation to public launch, but is **highly** dependent on partner's resource allocation. To reduce delays, have a front-end developer, artist, go-to-market strategy, and sufficient onboarding time ready. 
 
 ## What information do we need to provide to deploy our smart contracts?
 
@@ -142,12 +142,12 @@ Secondary marketplaces will automatically detect and display projects on your co
 
 ## Flex: What are the limitations around file size and file type for external assets? How many external assets can a project have?
 
-There are no explicit limitations on the contract side, neither for file size or type or how many external assets a project can have. Ultimately, this is at the discretion of the artist, but Art Blocks recommends paying close attention to ensure that artworks are as acessible as possible for as many different types of users as possible. Generally speaking, the above factors should be influenced by trying to achieve the best user experience for the artwork in terms of performance and load time.
+There are no explicit limitations on the contract side, neither for file size or type or how many external assets a project can have. Ultimately, this is at the discretion of the artist, but Art Blocks recommends paying close attention to ensure that artworks are as accessible as possible for as many different types of users as possible. Generally speaking, the above factors should be influenced by trying to achieve the best user experience for the artwork in terms of performance and load time.
 
 Some additional recommendations:
 
 - Try to keep the overall download size for users viewing the work to be under ~10mb OR ensure the artwork description mentions the heavier load/longer loading time. Additionally, consider whether or not it may make sense to have a loading indicator as part of the artwork itself.
-- When working with less common file types, remember to test on various platforms/browsers, to ensure the best cross-platform compatability possible.
+- When working with less common file types, remember to test on various platforms/browsers, to ensure the best cross-platform compatibility possible.
 
 ## Flex: Can JS external asset dependencies make external calls to other APIs/assets?
 
@@ -176,7 +176,7 @@ On the other hand, the **minterFilter contract** allows you to set max invocatio
 
 When `true`, `aproveArtistSplitProposals` is a feature thatallows artists to automatically change their royalty split payout address and the split percentage without requiring approval from the contract admin. This makes the process faster and more convenient for artists but may increase the risk of unauthorized changes to royalty wallets, which could complicate accounting or OFAC compliance. 
 
-If set to `alse` the contract admin will need to approve any changes to the artist's royalty wallet, adding a layer of security and control.
+If set to `else` the contract admin will need to approve any changes to the artist's royalty wallet, adding a layer of security and control.
 
 ## When should I enable GPU rendering?
 

--- a/creator-onboarding/readme/project-form-fields-guide.md
+++ b/creator-onboarding/readme/project-form-fields-guide.md
@@ -216,7 +216,7 @@ Artists are able to claim revenue after either:
 
 We ask that artists promptly collect revenue when it becomes available. To collect revenue:
 
-- Click the `Claim Revenue` button that becomes available in your artist dashboard, wich will prompt you to send a transaction
+- Click the `Claim Revenue` button that becomes available in your artist dashboard, which will prompt you to send a transaction
   - If the button is selected after the project has sold out, all revenue from the project will be distributed at the time of claim
   - If the button is selected after the auction reaches resting price, but before all tokens have been sold, revenue from previous purchases will be transferred. Revenue from subsequent purchases at resting price will be distributed immediately at the time of of each purchse.
 


### PR DESCRIPTION
Hey :wave:,

This PR will fix :

1 typo in `art-blocks-engine-onboarding/art-blocks-engine-101/Engine-royalty-registry-setup-(V2-only).md`
4 typos in `art-blocks-engine-onboarding/art-blocks-engine-101/faqs.md`
1 typo in `creator-onboarding/readme/project-form-fields-guide.md`


Best!