### PR TITLE
Shared minter suite runbooks

### DIFF
--- a/art-blocks-engine-onboarding/art-blocks-engine-101/Engine-project-launch.md
+++ b/art-blocks-engine-onboarding/art-blocks-engine-101/Engine-project-launch.md
@@ -6,52 +6,64 @@ order: 800
 
 This guide provides basic instructions for deploying and launching a new project on the V2 and V3 Engine smart contracts. You will learn how to create a project shell, assign a minter to each project, and setup the necessary configurations before minting and launching your project. This documentation aims to simplify the process and ensure a smooth project launch on the Art Blocks Engine platform.
 
-There are slight variations between V2 and V3 contracts, which will be noted in the relevant sections. 
+There are slight variations between V2 and V3 contracts, which will be noted in the relevant sections.
 
 ## Project Shell Deployment
 
 [!embed](https://www.loom.com/embed/9cb61eef17724107a6e7916d682c8bd5)
 
 1.  Collect the required information for the project:
-    -   Project title (e.g., "Fun Lines")
-    -   Artist's wallet address (e.g., 0x78592a6fBE68fEBf226040a5D25ad7e69F2FeAb6)
-    -   (V2 only) Price-per-mint specified in WEI (e.g., 350000000000000000, or 0.35 ETH)
-2.  Navigate to your Engine Core Contract on Etherscan and connect your wallet. You can find this link in your `DEPLOYMENTS.md` log. [https://goerli.etherscan.io/address/0xd2363Acbf8CdF01A5FdfcB8f0295e0a5dF94518D#code](https://goerli.etherscan.io/address/0xd2363Acbf8CdF01A5FdfcB8f0295e0a5dF94518D#code)) 
-    
+    - Project title (e.g., "Fun Lines")
+    - Artist's wallet address (e.g., 0x78592a6fBE68fEBf226040a5D25ad7e69F2FeAb6)
+    - (V2 only) Price-per-mint specified in WEI (e.g., 350000000000000000, or 0.35 ETH)
+2.  Navigate to your Engine Core Contract on Etherscan and connect your wallet. You can find this link in your `DEPLOYMENTS.md` log. [https://goerli.etherscan.io/address/0xd2363Acbf8CdF01A5FdfcB8f0295e0a5dF94518D#code](https://goerli.etherscan.io/address/0xd2363Acbf8CdF01A5FdfcB8f0295e0a5dF94518D#code))
 3.  Click the "Write contract" tab and use the `addProject` method to create a new project shell, specifying the information collected in step 1.
-    
 4.  Connect to the Art Blocks website with the artist wallet used in in Step 3. Your artist should be able to begin entering project details.
 
-	Testnet URL: `https://artist-staging.artblocks.io/engine/[flex OR fullyonchain]/projects/[coreContractAddress]/[projectID]` 
-	example: https://artist-staging.artblocks.io/engine/flex/projects/0x28b82AA5bb6d00363ae0FBC5ecaD689Ae49BC82B/0
+    Testnet URL: `https://artist-staging.artblocks.io/engine/[flex OR fullyonchain]/projects/[coreContractAddress]/[projectID]`
+    example: https://artist-staging.artblocks.io/engine/flex/projects/0x28b82AA5bb6d00363ae0FBC5ecaD689Ae49BC82B/0
 
-	Mainnet URL: `https://www.artblocks.io/engine/[flex OR fullyonchain]/projects/[coreContractAddress]/[projectID]`
-	example: https://www.artblocks.io/engine/fullyonchain/projects/0xa319C382a702682129fcbF55d514E61a16f97f9c/1
-    
+    Mainnet URL: `https://www.artblocks.io/engine/[flex OR fullyonchain]/projects/[coreContractAddress]/[projectID]`
+    example: https://www.artblocks.io/engine/fullyonchain/projects/0xa319C382a702682129fcbF55d514E61a16f97f9c/1
+
 5.  If you encounter issues finding or seeing your project on the Art Blocks site, disconnect and reconnect your wallet, ensuring you are connected with the previously specified artist wallet.
 
-## Assigning a Minter (V3 only)
+## Assigning a Minter (V3 only, New Shared Minter Suite)
+
+Minters are assigned on a per-project basis on V3 contracts, and minters must be assigned by the **artist's wallet**.
+
+When using the Art Blocks Shared Minter Suite, minter contracts are indexed by the Art Blocks subgraph, and can therefore be configured in the Artist Dashboard. For the artist wallet to assign and configure their minter, follow these steps:
+
+1. Assign the minter of your project in the artist dashboard.
+2. Configure the minter settings in the artist dashboard.
+3. If using more complex minters such as Polyptych minters, you may need to configure parameters on the shared randomizer contract via etherscan (outside of the artist dashboard). Please contact the Art Blocks team for assistance.
+
+## Assigning a Minter (V3 only, Legacy Non-Shared Minter Suite)
+
+!!!info
+We recommend using the new shared minter suite, which is easier to use and more flexible. If you are using the legacy non-shared minter suite, follow these instructions. For more information about migrating to the new shared minter suite, please see the [Minter Suite Migration Runbook](minter-suite-migration-runbook.md).
+!!!
 
 [!embed](https://www.loom.com/share/66f542b3ef024f7c80059115e76bae8d)
 
-Minters are assigned on a per-project basis on V3 contracts, and minters must be assigned by the **artist's wallet**. For the artist wallet to assign a minter, follow these steps: 
+Minters are assigned on a per-project basis on V3 contracts, and minters must be assigned by the **artist's wallet**. For the artist wallet to assign a minter, follow these steps:
 
 1.  Assign the minter to your project by using the `MinterFilterV1` contract found in your deployment file. The artist's wallet should use function #6 `setMinterForProject`, entering the `_projectID` and `_minterAddress`. You can find the minter address in your deployment log, which is pinned in your partner channel.
-    
 2.  Once the minter is linked to your project, set the project details on the minter contract. The deployed minter addresses can be found in your deployment file.
 
-	For example, if Art Blocks deployed a Dutch Auction minter for your core contract, navigate to the  `MinterDAExpV4`  contract on Etherscan (in your `DEPLOYMENT.md` log). Then, use the function `setAuctionDetails` to enter details like  `_projectId`,  `_auctionTimestampStart`,  `_priceDecayHalfLifeSeconds`,  `_startPrice`, and  `_basePrice`. Make sure this is done using the artist's wallet.
-    
+    For example, if Art Blocks deployed a Dutch Auction minter for your core contract, navigate to the `MinterDAExpV4` contract on Etherscan (in your `DEPLOYMENT.md` log). Then, use the function `setAuctionDetails` to enter details like `_projectId`, `_auctionTimestampStart`, `_priceDecayHalfLifeSeconds`, `_startPrice`, and `_basePrice`. Make sure this is done using the artist's wallet.
 
 ## Pre-mint-#0 Flight Check
 
 Before minting your first token (#0) on your new project shell, verify the following:
 
 1.  The baseTokenURI has been set, following the format:
+
 - Mainnet: http://token.artblocks.io/{CORE_CONTRACT_ADDRESS}/
 - Testnet: https://token.staging.artblocks.io/{CONTRACT_ADDRESS}/
+
 2.  The max invocations for the project have been set. (note: project size **cannot** be increased once set on V3 contracts)
-3. Mint through your own front end. On testnet, you'll want to test each minter type and currency you plan to use on mainnet.
+3.  Mint through your own front end. On testnet, you'll want to test each minter type and currency you plan to use on mainnet.
 
 ## Pre-launch (pre-open-minting) Flight Check
 
@@ -59,7 +71,7 @@ For a project to be avaialble for public purchase, the project must be activated
 
 tldr:
 inactive + paused (default state) = private project shell and unable to purchase
-active + paused = public project shell and ***only*** the artist wallet can purchase
+active + paused = public project shell and **_only_** the artist wallet can purchase
 active + unpaused = open to purchase
 
 Before launching your project for open minting, verify the following:

--- a/art-blocks-engine-onboarding/art-blocks-engine-101/Engine-project-launch.md
+++ b/art-blocks-engine-onboarding/art-blocks-engine-101/Engine-project-launch.md
@@ -32,11 +32,17 @@ There are slight variations between V2 and V3 contracts, which will be noted in 
 
 Minters are assigned on a per-project basis on V3 contracts, and minters must be assigned by the **artist's wallet**.
 
-When using the Art Blocks Shared Minter Suite, minter contracts are indexed by the Art Blocks subgraph, and can therefore be configured in the Artist Dashboard. For the artist wallet to assign and configure their minter, follow these steps:
+> note: for legacy minter suite directions, see the next section
 
-1. Assign the minter of your project in the artist dashboard.
-2. Configure the minter settings in the artist dashboard.
-3. If using more complex minters such as Polyptych minters, you may need to configure parameters on the shared randomizer contract via etherscan (outside of the artist dashboard). Please contact the Art Blocks team for assistance.
+!!!info
+Art Blocks is working on a new creator dashboard that will more easily facilitate the minter assignment process. This will only be possible using the new shared minter suite, because those minters are indexed by the subgraph. Until the new creator dashboard is released, please follow these instructions to assign a minter to your project.
+!!!
+
+1.  Assign the minter to your project by using the `MinterFilterV2` contract found in your deployment file. The artist's wallet should use function #9 `setMinterForProject`, entering the `_projectID`, `_coreContract` address, and `_minter` address. You can get the globally approved minter addresses via the `getAllGloballyApprovedMinters()` view function on the `MinterFilterV2` contract.
+
+2.  Once the minter is linked to your project, set the project details on the minter contract.
+
+    For example, if you are using a shared Dutch Auction minter, navigate to the contract on Etherscan. Then, use the function `setAuctionDetails` to enter details like `_projectId`, `_coreContract`, `_auctionTimestampStart`, `_priceDecayHalfLifeSeconds`, `_startPrice`, and `_basePrice`. This must be done using the artist's wallet.
 
 ## Assigning a Minter (V3 only, Legacy Non-Shared Minter Suite)
 

--- a/art-blocks-engine-onboarding/art-blocks-engine-101/faqs.md
+++ b/art-blocks-engine-onboarding/art-blocks-engine-101/faqs.md
@@ -17,17 +17,16 @@ order: 100
 - [What's the difference between a testnet token and a mainnet token?](https://docs.artblocks.io/creator-docs/art-blocks-engine-onboarding/art-blocks-engine-101/faqs/#whats-the-difference-between-a-testnet-token-and-a-mainnet-token)
 - [Flex: What are the limitations around file size and file type for external assets? How many external assets can a project have?](https://docs.artblocks.io/creator-docs/art-blocks-engine-onboarding/art-blocks-engine-101/faqs/#flex-what-are-the-limitations-around-file-size-and-file-type-for-external-assets-how-many-external-assets-can-a-project-have)
 - [Flex: Can JS external asset dependencies make external calls to other APIs/assets?](https://docs.artblocks.io/creator-docs/art-blocks-engine-onboarding/art-blocks-engine-101/faqs/#flex-can-js-external-asset-dependencies-make-external-calls-to-other-apisassets)
-- [How does project size work on the minterFilter contract vs Core contract?](https://docs.artblocks.io/creator-docs/art-blocks-engine-onboarding/art-blocks-engine-101/faqs/#how-does-project-size-work-on-the-minterfilter-contract-vs-core-contract)
+- [How does project size work on the Minter contract vs Core contract?](https://docs.artblocks.io/creator-docs/art-blocks-engine-onboarding/art-blocks-engine-101/faqs/#how-does-project-size-work-on-the-minter-contract-vs-core-contract)
 - [How does `autoApproveArtistSplitProposals` work?](https://docs.artblocks.io/creator-docs/art-blocks-engine-onboarding/art-blocks-engine-101/faqs/#how-does-autoApproveArtistSplitProposals-work)
 - [When should I enable GPU rendering?](https://docs.artblocks.io/creator-docs/art-blocks-engine-onboarding/art-blocks-engine-101/faqs/#when-should-I-enable-GPU-rendering)
 
 ## What are the Art Blocks Engine offerings?
 
-**Art Blocks Engine:**   
+**Art Blocks Engine:**  
 Used for on-chain storage of generative systems. Projects can use no dependencies or one dependency from a list of decentralized libraries. [See the allowed dependencies here.](https://docs.artblocks.io/creator-docs/creator-onboarding/readme/#limited-dependencies)
 
-
-**Art Blocks Engine Flex:**   
+**Art Blocks Engine Flex:**  
 Allows generative systems to reference off-chain assets stored on IPFS or Arweave, enabling creative tools like photography, AI, and GAN.
 
 Email us at Engine@artblocks.io to discuss which offering best suits your needs.
@@ -39,14 +38,16 @@ For a new partnership, the standard current Art Blocks Engine offerings include:
 1. Deployment of Engine smart contracts suite to testnet and mainnet (includes gas costs).
 2. Integration of deployed Core contract with decentralized Graph indexing architecture on testnet and mainnet, includes GRT costs incurred for subgraph update deployment.
 3. Integration of deployed contracts and subgraph with Art Blocks' project setup site and rendering/metadata infrastructure (APIs: Token, Generator, Rendered Image).
+4. Integration with the shared Art Blocks Minter Suite. These are the same minting contracts used by Art Blocks Flagship. Benefits include having the ability to configure minter settings in the Artist Dashboard, the ability to query minter state via subgraph or Hasura queries, and the ability to use the Art Blocks minting SDK to more easily mint tokens on your frontend.
 
 ## What effect does ‘locking’ a project have?
 
 Locking a project (specifically on V2 Contracts) permanently freezes the artist name, project name, project scripts, project license, and project IPFS hash on the blockchain. Additionally, maximum invocations of a project can never be increased.
 
- **Locked projects can not be unlocked**
+**Locked projects can not be unlocked**
 
 A summary of how the smart contract functions behave:
+
 - `toggleProjectIsLocked`
   - only callable by admin whitelisted wallets on the core contract
   - can only lock projects (i.e. **locked projects can not be unlocked**)
@@ -76,7 +77,7 @@ Contact your account manager for an invite link to the private Discord server.
 
 ## How long will the process take from start to public launch?
 
-The process typically takes 10 weeks from initial conversation to public launch, but is **highly** dependent on partner's resource allocation. To reduce delays, have a front-end developer, artist, go-to-market strategy, and sufficient onboarding time ready. 
+The process typically takes 10 weeks from initial conversation to public launch, but is **highly** dependent on partner's resource allocation. To reduce delays, have a front-end developer, artist, go-to-market strategy, and sufficient onboarding time ready.
 
 ## What information do we need to provide to deploy our smart contracts?
 
@@ -87,21 +88,20 @@ To get started, you'll provide our team with:
 - The name you’ll use for tokens from your contract (e.g., for Art Blocks, it is "Art Blocks")
 - The ticker symbol you’ll use for tokens from your contract (e.g., for Art Blocks, it is "BLOCKS")
 - Deployment Type: V3 Onchain Engine or V3 Flex Engine
-- Minter Type: set price eth only, set price custom erc20, merkle tree allowlist, holder-gated, linear DA, exponential DA, and exponential DA with settlement
 - Starting project ID # (>=0):
-- Set `autoApproveArtistSplitProposals` true or false**
+- Set `autoApproveArtistSplitProposals` true or false\*\*
 
-**It needs to be set at deployment and cannot be changed later. 
+\*\*It needs to be set at deployment and cannot be changed later.
 
-tldr - if true, artist royalty wallet changes are auto-approved. If false, the contract admin will need to approve the artist's royalty wallet changes. This is an added check to ensure your artists aren't changing royalty wallets to a random address, which could complicate accounting/ OFAC compliance. 
+tldr - if true, artist royalty wallet changes are auto-approved. If false, the contract admin will need to approve the artist's royalty wallet changes. This is an added check to ensure your artists aren't changing royalty wallets to a random address, which could complicate accounting/ OFAC compliance.
 
 We cannot deploy your contract until you provide the above information. **The name and symbol tied to your contract cannot change once your contract is deployed.**
 
 ## Does Art Blocks create a front-end site for our project?
 
-No, partners are responsible for creating and designing their customer-facing experience. 
+No, partners are responsible for creating and designing their customer-facing experience.
 
-However, we do have a [front-end React template](https://github.com/ArtBlocks/artblocks-engine-react) with web3 functionality you need to launch a minting site. You will still be responsible for designing the user exerpeicne, but this significantly reduces the time needed to complete a front-end. 
+However, we do have a [front-end React template](https://github.com/ArtBlocks/artblocks-engine-react) with web3 functionality you need to launch a minting site. You will still be responsible for designing the user exerpeicne, but this significantly reduces the time needed to complete a front-end.
 
 ## How long will each stage of the process take?
 
@@ -112,8 +112,8 @@ However, we do have a [front-end React template](https://github.com/ArtBlocks/ar
 5. Contract configuration & testnet deployment - **1 week**
 6. Testnet infrastructure integration -** 1 week**
 7. Integration with partner’s site - **Varies** (dependent on partner)
-8. Test mints on partner site - **Varies** (dependent on partner) 
-9.  Deployment to mainnet - **1-2 weeks**
+8. Test mints on partner site - **Varies** (dependent on partner)
+9. Deployment to mainnet - **1-2 weeks**
 10. Mainnet infrastructure integration -** Varies** (dependent on partner)
 11. Mint #0 - **Instant**
 12. Project launch! - **1 week** after step 11
@@ -124,17 +124,17 @@ However, we do have a [front-end React template](https://github.com/ArtBlocks/ar
 This is the smart contract that controls the artwork created by the artist. No financial transactions occur on this smart contract.
 
 **AdminACL:**
-By default, Engine smart contracts have two sets of permissions, Admin and Artist. The AdminACL contract controls which wallets can access which functions on your core contract. If you'd like to assign more granular control of your smart contract to different wallets, you can fork and customize the AdminACL contract. 
+By default, Engine smart contracts have two sets of permissions, Admin and Artist. The AdminACL contract controls which wallets can access which functions on your core contract. If you'd like to assign more granular control of your smart contract to different wallets, you can fork and customize the AdminACL contract.
 
 **Minter Filer:**
-The minter filter configures minter-types to specific projects. 
+The minter filter configures minter-types to specific projects.
 
 **Minter contract:**
 These smart contracts receive funds and split them between the artist(s) and the platform. Artists receive funds directly from these contracts.
 
 ## How do we list Art Blocks Engine pieces on secondary markets?
 
-Secondary marketplaces will automatically detect and display projects on your contract. If you’d like each project to have its own storefront on OpenSea, please contact an account manager to facilitate the change. 
+Secondary marketplaces will automatically detect and display projects on your contract. If you’d like each project to have its own storefront on OpenSea, please contact an account manager to facilitate the change.
 
 ## What's the difference between a testnet token and a mainnet token?
 
@@ -161,20 +161,20 @@ The value of `paused` is determined by artist, whereas `active` is determined by
 
 Art Blocks uses the decentralized Graph network to index on-chain data in our publicly available subgraph. There can be a slight delay between the first block confirmation on the ethereum network for a transaction and that transaction being indexed by our subgraph. To mitigate this, as an Art Blocks engine provider, your client should be waiting multiple block confirmations (we recommend at least 2 blocks) before it shows the generator view to the user. The generator will return an error message if the token is not indexed yet, accompanied by 4XX status code. Many clients also employ a polling strategy, only showing the requested generator view once the requested generator url is returning a 2XX status code.
 
-## How does project size work on the minterFilter contract vs Core contract?
+## How does project size work on the Minter contract vs Core contract?
 
-A project's max invocations on Art Blocks contracts are handled differently on the Core contract and the minterFilter contract.
+A project's max invocations on Art Blocks contracts are handled differently on the Core contract and the Minter contract.
 
 On the **Core contract**, setting a project size establishes the project's maximum size, and this value **cannot** be increased once set. The max invocations on the core contract define the absolute upper limit for the number of mints for a specific project.
 
-On the other hand, the **minterFilter contract** allows you to set max invocations for a specific minter using the `manuallyLimitProjectMaxInvocations` function. This setting does not lock the project size but controls the maximum number of mints allowed by that particular minter. When updating the maxInvocations value for a project in the minterFilter contract, you must adhere to these conditions:
+On the other hand, each **Minter contract** allows you to set max invocations for the specific minter using the `manuallyLimitProjectMaxInvocations` function. This setting does not lock the project size but controls the maximum number of mints allowed by that particular minter. When updating the maxInvocations value for a project in the Minter contract, you must adhere to these conditions:
 
-1. The new value of _maxInvocations should not be greater than the maxInvocations set in the core contract.
-2. The new value of _maxInvocations should not be less than the current number of invocations.
+1. The new value of \_maxInvocations should not be greater than the maxInvocations set in the core contract.
+2. The new value of \_maxInvocations should not be less than the current number of invocations.
 
 ## How does `autoApproveArtistSplitProposals` work?
 
-When `true`, `aproveArtistSplitProposals` is a feature thatallows artists to automatically change their royalty split payout address and the split percentage without requiring approval from the contract admin. This makes the process faster and more convenient for artists but may increase the risk of unauthorized changes to royalty wallets, which could complicate accounting or OFAC compliance. 
+When `true`, `aproveArtistSplitProposals` is a feature thatallows artists to automatically change their royalty split payout address and the split percentage without requiring approval from the contract admin. This makes the process faster and more convenient for artists but may increase the risk of unauthorized changes to royalty wallets, which could complicate accounting or OFAC compliance.
 
 If set to `else` the contract admin will need to approve any changes to the artist's royalty wallet, adding a layer of security and control.
 

--- a/art-blocks-engine-onboarding/art-blocks-engine-101/faqs.md
+++ b/art-blocks-engine-onboarding/art-blocks-engine-101/faqs.md
@@ -38,7 +38,7 @@ For a new partnership, the standard current Art Blocks Engine offerings include:
 1. Deployment of Engine smart contracts suite to testnet and mainnet (includes gas costs).
 2. Integration of deployed Core contract with decentralized Graph indexing architecture on testnet and mainnet, includes GRT costs incurred for subgraph update deployment.
 3. Integration of deployed contracts and subgraph with Art Blocks' project setup site and rendering/metadata infrastructure (APIs: Token, Generator, Rendered Image).
-4. Integration with the shared Art Blocks Minter Suite. These are the same minting contracts used by Art Blocks Flagship. Benefits include having the ability to configure minter settings in the Artist Dashboard, the ability to query minter state via subgraph or Hasura queries, and the ability to use the Art Blocks minting SDK to more easily mint tokens on your frontend.
+4. (in-migration) Integration with the shared Art Blocks Minter Suite. Art Blocks is rolling out a shared minter suite that will be available for Engine Partners to use to mint their projects. Previously deployed V3 Engine contracts will have the ability to migrate to the new shared minter suite. This means the same minting contracts used for Art Blocks Flagship will be available for Engine partners. In addition to the ability to query minter state via subgraph or Hasura queries, Art Blocks has future plans to expand our offering to include the ability to configure minter settings in an Artist Dashboard, and the ability to use a new Art Blocks minting SDK to more easily mint tokens on your frontend.
 
 ## What effect does ‘locking’ a project have?
 
@@ -88,6 +88,8 @@ To get started, you'll provide our team with:
 - The name you’ll use for tokens from your contract (e.g., for Art Blocks, it is "Art Blocks")
 - The ticker symbol you’ll use for tokens from your contract (e.g., for Art Blocks, it is "BLOCKS")
 - Deployment Type: V3 Onchain Engine or V3 Flex Engine
+- Minter Type: set price eth only, set price custom erc20, merkle tree allowlist holder-gated, linear DA, exponential DA, and exponential DA with settlement
+  - _note: minter selection will not be needed after migrating to shared minter suite_
 - Starting project ID # (>=0):
 - Set `autoApproveArtistSplitProposals` true or false\*\*
 

--- a/art-blocks-engine-onboarding/art-blocks-engine-101/minter-suite-migration-runbook.md
+++ b/art-blocks-engine-onboarding/art-blocks-engine-101/minter-suite-migration-runbook.md
@@ -7,10 +7,9 @@ order: -5
 This page provides a step-by-step guide on how to migrate a V3 Art Blocks Engine core contract from the legacy non-shared minter suite to the new shared minter suite. This migration is required for all V3 Engine contracts that want to use the new shared minter suite, which has the following benefits:
 
 - All minter contracts are indexed by the Art Blocks subgraph, and can therefore be configured in the Artist Dashboard
-- All new minter contracts developed for Art Blocks Flagship will be available for use by Engine projects\*
+- All minter Art Blocks Flagship minting contracts become available for use by Engine projects
+- The new minting SDK can be used to simplify Engine partners frontend minting codebases
 - Collectors can purchase from the same trusted contract they interact with on Flagship.
-
-> \*This is the general plan, but may be subject to change for highly complex minters due to technical limitations (although this is not expected to be the case).
 
 Migration is not available for V2 Engine contracts; for Engine partners that wish to upgrade to a V3 Engine contract, please contact the Art Blocks team.
 
@@ -20,11 +19,11 @@ Migration is not required for V3 Engine contracts that wish to continue using th
 
 ### 1. Engine partner frontend updated to support new minter suite
 
-The Engine partner's frontend must be updated to support the new shared minter suite. To help with this transition, the Art Blocks team has created a new minting SDK that can be used to support the new shared minter suite. The SDK details will be added to this page when they become available.
+The Engine partner's frontend must be updated to support the new shared minter suite. To help with this transition, the Art Blocks team has created a new minting SDK that can be used to support the new shared minter suite. Documentation for the SDK will be referenced here when it becomes available.
 
 ### 2. Schedule downtime for any live projects
 
-The migration process requires all projects switch to a new minter. All live projects will should be paused during the migration process. Switching to the new minter filter is quick, but after migrating to the new minter filter, the artist of every live project must configure their minter in the new minter suite. This is also a relatively quick process, but it is fully reliant on coordinating with artists to be ready to re-configure their minters after the switch.
+The migration process requires all artists with live projects configure a new minter. All live projects should be paused during the migration process. Switching to the new minter filter is simple, but after migrating to the new minter filter, the artist of every live project must configure their minter in the new minter suite. This is also only a few transactions, but it is fully reliant on coordinating with artists to be ready to re-configure their minters after switching to the new minter filter.
 
 ### 3. Core contract admin sends migration transactions (testnet before mainnet)
 
@@ -34,23 +33,23 @@ The Engine partner's core contract admin should send 2 transactions to the core 
 
 2. Engine Admin calls `updateMinterContract` on the core contract, passing in the address of the shared minter filter. The shared minter filter address will be populated here once the Art Blocks team deploys the shared minter filter contract to mainnet (as well as testnets).
 
-Congratulations! You are now using the new shared minter suite. However, open projects are not yet using the new shared minter contracts. The next step is to migrate your projects to the new shared minter contracts.
+You are now using the new shared minter suite!
 
 ### 4. Artists re-configure minters for ALL LIVE PROJECTS
 
-Artists must re-configure their minters for **all live projects**. This is a quick process, but requires coordination with artists to ensure they are ready to re-configure their minters after the switch.
+**AFTER** step 3, artists must re-configure their minters for **all live projects**. This is a quick process, but requires coordination with artists to ensure they are ready to re-configure their minters after the switch.
 
-Artists can re-configure their minters in the Artist Dashboard. The Artist Dashboard is updated to support the new shared minter suite for Art Blocks Engine contracts. The process for _most_ open projects will likely be to switch to a fixed price minter. The steps to complete this process are:
+Artists can re-configure their minters via the Artist Dashboard. The Artist Dashboard is updated to support the new shared minter suite for Art Blocks Engine contracts. The process for _most_ open projects will likely be to switch to a fixed price minter. The steps to complete switching to a fixed price minter are:
 
-1. Artist navigates to the Artist Dashboard via the `edit` button on their project page on the Art Blocks website
+1. Artist navigates to the Artist Dashboard via the `edit` button on their project page on the Art Blocks website (while connected with their artist wallet)
 2. (recommended, but not required) Artist pauses their project
 3. Artist selects the "Minter" tab
 4. Artist selects the "Fixed Price ETH" minter and sends transaction to assign the minter to their project
-5. Artist sets max invocations if desired to be less than the remaining max invocations defined at the project-level (sends transaction)
+5. (optional) If max invocations should be limited by the minter, Artist sets max invocations to desired value (sends transaction)
 6. Artist sets the price per per token in wei (sends transaction)
 7. Artist unpauses their project (if paused in step 2) (sends transaction)
 
-Congratulations! Your project is now using the new shared minter suite and live for minting!
+Your project is now using the new shared minter suite and live for minting!
 
 ### 5. Engine partner monitors migration progress
 
@@ -58,9 +57,9 @@ It is recommended that the Engine partner monitor the migration process to ensur
 
 ### 6. Add any custom minters to the shared minter suite
 
-The new shared minter suite provides all Art Blocks Flagship minters to Engine projects. However, if the Engine partner has any custom minters that they would like to use, they can be added to the shared minter suite. Please contact the Art Blocks team for assistance. Additionally, at this time, custom, one-off minters will not be indexed in the Art Blocks Subgraph or API. This is likely the same as the current situation for custom minters in the legacy non-shared minter suite.
+The new shared minter suite provides all Art Blocks Flagship minters to Engine projects. However, if the Engine partner has any custom, one-off minters that they would like to use for their core contract, they can be added for their specific contract. Please contact the Art Blocks team for assistance. Note that at this time, custom, one-off minters will not be indexed in the Art Blocks Subgraph or API. This is likely not a change for custom minters being used prior to migration.
 
-Custom minters will need very slight modifications to work with the shared minter suite. This is because the minter must specify which core contract it is minting on to the minter filter contract. The Art Blocks team can assist with providing guidance on how to update one-off minters during the migration process if needed.
+Custom minters will need very slight modifications to work with the shared minter suite. This is because the minter must specify which core contract it is minting on to the minter filter contract. The Art Blocks team can assist with providing guidance on how to update one-off minters during the migration process, if needed.
 
 ### 7. Explore new minter suite features
 

--- a/art-blocks-engine-onboarding/art-blocks-engine-101/minter-suite-migration-runbook.md
+++ b/art-blocks-engine-onboarding/art-blocks-engine-101/minter-suite-migration-runbook.md
@@ -1,0 +1,93 @@
+---
+order: -5
+---
+
+# Minter Suite Migration Runbook
+
+This page provides a step-by-step guide on how to migrate a V3 Art Blocks Engine core contract from the legacy non-shared minter suite to the new shared minter suite. This migration is required for all V3 Engine contracts that want to use the new shared minter suite, which has the following benefits:
+
+- All minter contracts are indexed by the Art Blocks subgraph, and can therefore be configured in the Artist Dashboard
+- All new minter contracts developed for Art Blocks Flagship will be available for use by Engine projects\*
+- Collectors can purchase from the same trusted contract they interact with on Flagship.
+
+> \*This is the general plan, but may be subject to change for highly complex minters due to technical limitations (although this is not expected to be the case).
+
+Migration is not available for V2 Engine contracts; for Engine partners that wish to upgrade to a V3 Engine contract, please contact the Art Blocks team.
+
+Migration is not required for V3 Engine contracts that wish to continue using the legacy non-shared minter suite. However, we recommend migrating to the new shared minter suite for the benefits listed above.
+
+## Migration Steps
+
+### 1. Engine partner frontend updated to support new minter suite
+
+The Engine partner's frontend must be updated to support the new shared minter suite. To help with this transition, the Art Blocks team has created a new minting SDK that can be used to support the new shared minter suite. The SDK details will be added to this page when they become available.
+
+### 2. Schedule downtime for any live projects
+
+The migration process requires all projects switch to a new minter. All live projects will should be paused during the migration process. Switching to the new minter filter is quick, but after migrating to the new minter filter, the artist of every live project must configure their minter in the new minter suite. This is also a relatively quick process, but it is fully reliant on coordinating with artists to be ready to re-configure their minters after the switch.
+
+### 3. Core contract admin sends migration transactions (testnet before mainnet)
+
+The Engine partner's core contract admin should send 2 transactions to the core contract:
+
+1. Engine Admin calls `updateRandomizerAddress` on the core contract, passing in the address of the shared randomizer. The shared randomizer address will be populated here once the Art Blocks team deploys the shared randomizer contract to mainnet (as well as testnets).
+
+2. Engine Admin calls `updateMinterContract` on the core contract, passing in the address of the shared minter filter. The shared minter filter address will be populated here once the Art Blocks team deploys the shared minter filter contract to mainnet (as well as testnets).
+
+Congratulations! You are now using the new shared minter suite. However, open projects are not yet using the new shared minter contracts. The next step is to migrate your projects to the new shared minter contracts.
+
+### 4. Artists re-configure minters for ALL LIVE PROJECTS
+
+Artists must re-configure their minters for **all live projects**. This is a quick process, but requires coordination with artists to ensure they are ready to re-configure their minters after the switch.
+
+Artists can re-configure their minters in the Artist Dashboard. The Artist Dashboard is updated to support the new shared minter suite for Art Blocks Engine contracts. The process for _most_ open projects will likely be to switch to a fixed price minter. The steps to complete this process are:
+
+1. Artist navigates to the Artist Dashboard via the `edit` button on their project page on the Art Blocks website
+2. (recommended, but not required) Artist pauses their project
+3. Artist selects the "Minter" tab
+4. Artist selects the "Fixed Price ETH" minter and sends transaction to assign the minter to their project
+5. Artist sets max invocations if desired to be less than the remaining max invocations defined at the project-level (sends transaction)
+6. Artist sets the price per per token in wei (sends transaction)
+7. Artist unpauses their project (if paused in step 2) (sends transaction)
+
+Congratulations! Your project is now using the new shared minter suite and live for minting!
+
+### 5. Engine partner monitors migration progress
+
+It is recommended that the Engine partner monitor the migration process to ensure that all artists have successfully re-configured their minters. Additionally, the Engine partner should use diligence to ensure that purchases and payment splits after the migration are working as expected.
+
+### 6. Add any custom minters to the shared minter suite
+
+The new shared minter suite provides all Art Blocks Flagship minters to Engine projects. However, if the Engine partner has any custom minters that they would like to use, they can be added to the shared minter suite. Please contact the Art Blocks team for assistance. Additionally, at this time, custom, one-off minters will not be indexed in the Art Blocks Subgraph or API. This is likely the same as the current situation for custom minters in the legacy non-shared minter suite.
+
+Custom minters will need very slight modifications to work with the shared minter suite. This is because the minter must specify which core contract it is minting on to the minter filter contract. The Art Blocks team can assist with providing guidance on how to update one-off minters during the migration process if needed.
+
+### 7. Explore new minter suite features
+
+The new shared minter suite provides all Art Blocks Flagship minters to Engine projects. Feel free to explore integrating new minters into your product!
+
+## Migration FAQ
+
+### What happens if an artist does not re-configure their minter?
+
+If an artist does not re-configure their minter, their project will not be able to mint tokens. The artist will need to re-configure their minter before their project can mint tokens.
+
+### What happens if an artist re-configures their minter incorrectly?
+
+If an artist re-configures their minter incorrectly, best case scenario is that their project will not be able to mint tokens, and troubleshooting can identify the issue. Worst case scenario is that their project will be able to mint tokens, but the price per token will be incorrect (e.g. incorrect price entered) or the maximum invocations will be too high (e.g. forgot to set minter-max-invocations to a lower value than set on the core contract, if desired). For these reasons, artists should use diligence when re-configuring their minters.
+
+### What happens if I migrate to the new shared minter suite?
+
+If you migrate to the new shared minter suite, you will be able to use any new minters developed for Art Blocks Flagship. Additionally, you will be able to use the Artist Dashboard to configure your minters, because your minter suite will be indexed. You will also be able to use the new minting SDK to simplify your minting process.
+
+### What happens if I do not migrate to the new shared minter suite?
+
+If you do not migrate to the new shared minter suite, nothing will change, but you will miss out on new developments. You will not be able to use any new minters developed for Art Blocks Flagship. Additionally, you will not be able to use the Artist Dashboard to configure your minters, because your minter suite will not be indexed. You will need to continue to use the legacy non-shared minter suite.
+
+### What happens if I migrate to the new shared minter suite, but I do not want to use the Artist Dashboard to configure my minters?
+
+If you migrate to the new shared minter suite, but you do not want to use the Artist Dashboard to configure your minters, you can continue to configure your minters via your frontend, etherscan, etc., but your process will be slightly updated to support the new shared minter suite. The Art Blocks team can assist with providing guidance on how to update your process during the migration process if needed.
+
+### What happens if I migrate to the new shared minter suite, but I do not want to use the new minting SDK?
+
+If you migrate to the new shared minter suite, but you do not want to use the new minting SDK, you can continue to use your existing minting process, but your process will be slightly updated to support the new shared minter suite.

--- a/art-blocks-engine-onboarding/art-blocks-engine-101/minter-suite-migration-runbook.md
+++ b/art-blocks-engine-onboarding/art-blocks-engine-101/minter-suite-migration-runbook.md
@@ -6,10 +6,10 @@ order: -5
 
 This page provides a step-by-step guide on how to migrate a V3 Art Blocks Engine core contract from the legacy non-shared minter suite to the new shared minter suite. This migration is required for all V3 Engine contracts that want to use the new shared minter suite, which has the following benefits:
 
-- All minter contracts are indexed by the Art Blocks subgraph, and can therefore be configured in the Artist Dashboard
+- All minter contracts are indexed by the Art Blocks subgraph, and can therefore be configured in the new Artist Dashboard website (coming soon)
 - All minter Art Blocks Flagship minting contracts become available for use by Engine projects
-- The new minting SDK can be used to simplify Engine partners frontend minting codebases
 - Collectors can purchase from the same trusted contract they interact with on Flagship.
+- Art Blocks will release an SDK to simplify the minting process for Engine projects (coming soon)
 
 Migration is not available for V2 Engine contracts; for Engine partners that wish to upgrade to a V3 Engine contract, please contact the Art Blocks team.
 
@@ -19,11 +19,28 @@ Migration is not required for V3 Engine contracts that wish to continue using th
 
 ### 1. Engine partner frontend updated to support new minter suite
 
-The Engine partner's frontend must be updated to support the new shared minter suite. To help with this transition, the Art Blocks team has created a new minting SDK that can be used to support the new shared minter suite. Documentation for the SDK will be referenced here when it becomes available.
+The Engine partner's frontend must be updated to support the new shared minter suite. In general, the new shared minter suite requires the following changes:
+
+- When specifying a project to configure or purchase from, an additional input arg of `coreContract` (address) must be specified. This is because one minter/minter filter contract is used for many core contracts.
+- View functions on the minter contracts may have changed slightly. This is due to some minor architectural changes to the minter contracts that we believe simplifies their codebase and make them more extensible.
+
+The source code of all new, shared minter contracts is available on the [Art Blocks smart contracts monrorepo](https://github.com/ArtBlocks/artblocks-contracts/tree/main/packages/contracts/contracts/minter-suite/Minters). The complete list of all new, shared minter contracts is:
+
+- MinterSetPriceV5
+- MinterSetPriceERC20V5
+- MinterSetPriceMerkleV5
+- MinterSetPriceHolderV5
+- MinterSetPricePolyptychV5
+- MinterSetPricePolyptychERC20V5
+- MinterDAExpV5
+- MinterDALinV5
+- MinterDAExpSettlementV2
+
+In the coming months, the Art Blocks team will be releasing a new minting SDK that can be used to support the new shared minter suite. Documentation for the SDK will be referenced here when it becomes available.
 
 ### 2. Schedule downtime for any live projects
 
-The migration process requires all artists with live projects configure a new minter. All live projects should be paused during the migration process. Switching to the new minter filter is simple, but after migrating to the new minter filter, the artist of every live project must configure their minter in the new minter suite. This is also only a few transactions, but it is fully reliant on coordinating with artists to be ready to re-configure their minters after switching to the new minter filter.
+The migration process requires all artists with live projects configure a new minter. All live projects should be paused during the migration process. Switching to the new minter filter is simple, but after migrating to the new minter filter, the artist of every live project must configure their minter in the new minter suite. This is also only a few transactions, but it is fully reliant on coordinating with artists to be ready to re-configure minters of open projects after switching to the new minter filter.
 
 ### 3. Core contract admin sends migration transactions (testnet before mainnet)
 
@@ -39,9 +56,9 @@ You are now using the new shared minter suite!
 
 **AFTER** step 3, artists must re-configure their minters for **all live projects**. This is a quick process, but requires coordination with artists to ensure they are ready to re-configure their minters after the switch.
 
-Artists can re-configure their minters via the Artist Dashboard. The Artist Dashboard is updated to support the new shared minter suite for Art Blocks Engine contracts. The process for _most_ open projects will likely be to switch to a fixed price minter. The steps to complete switching to a fixed price minter are:
+Artists can re-configure their minters via the (new) Artist Dashboard. The process for _most_ open projects will likely be to switch to a fixed price minter. The steps to complete switching to a fixed price minter are:
 
-1. Artist navigates to the Artist Dashboard via the `edit` button on their project page on the Art Blocks website (while connected with their artist wallet)
+1. Artist navigates to the new Artist Dashboard (while connected with their artist wallet)
 2. (recommended, but not required) Artist pauses their project
 3. Artist selects the "Minter" tab
 4. Artist selects the "Fixed Price ETH" minter and sends transaction to assign the minter to their project
@@ -109,7 +126,7 @@ If you do not migrate to the new shared minter suite, nothing will change, but y
 
 ### What happens if I migrate to the new shared minter suite, but I do not want to use the Artist Dashboard to configure my minters?
 
-If you migrate to the new shared minter suite, but you do not want to use the Artist Dashboard to configure your minters, you can continue to configure your minters via your frontend, etherscan, etc., but your process will be slightly updated to support the new shared minter suite. The Art Blocks team can assist with providing guidance on how to update your process during the migration process if needed.
+If you migrate to the new shared minter suite, but you do not want to use the Artist Dashboard to configure your minters, you can continue to configure your minters via your frontend, etherscan, etc., but your process will be slightly updated to support the new shared minter suite. Comparing the new minter contracts and the legacy minter contracts will help you understand the changes.
 
 ### What happens if I migrate to the new shared minter suite, but I do not want to use the new minting SDK?
 

--- a/art-blocks-engine-onboarding/art-blocks-engine-101/minter-suite-migration-runbook.md
+++ b/art-blocks-engine-onboarding/art-blocks-engine-101/minter-suite-migration-runbook.md
@@ -57,13 +57,37 @@ It is recommended that the Engine partner monitor the migration process to ensur
 
 ### 6. Add any custom minters to the shared minter suite
 
-The new shared minter suite provides all Art Blocks Flagship minters to Engine projects. However, if the Engine partner has any custom, one-off minters that they would like to use for their core contract, they can be added for their specific contract. Please contact the Art Blocks team for assistance. Note that at this time, custom, one-off minters will not be indexed in the Art Blocks Subgraph or API. This is likely not a change for custom minters being used prior to migration.
+The new shared minter suite provides all Art Blocks Flagship minters to Engine projects. However, if the Engine partner has any custom, one-off minters that they would like to use for their core contract, they can be added for their specific contract. Please see the [section below](#adding-a-custom-one-off-minter-to-the-shared-minter-suite) for steps on how to do this. Note that at this time, custom, one-off minters will not be indexed in the Art Blocks Subgraph or API. This is likely not a change for custom minters being used prior to migration.
 
 Custom minters will need very slight modifications to work with the shared minter suite. This is because the minter must specify which core contract it is minting on to the minter filter contract. The Art Blocks team can assist with providing guidance on how to update one-off minters during the migration process, if needed.
 
 ### 7. Explore new minter suite features
 
 The new shared minter suite provides all Art Blocks Flagship minters to Engine projects. Feel free to explore integrating new minters into your product!
+
+## Adding a custom, one-off minter to the shared minter suite
+
+Some Engine partners may wish to implement custom, one-off minters to the shared minter suite. This is able to be done by the admin of an Engine partner's core contract. The steps to add a custom, one-off minter to the shared minter suite are as follows:
+
+### 1. Write the custom minter contract
+
+The Engine partner will need to write the custom minter contract. The Art Blocks team can assist with providing guidance on how to translate a previously written, non-shared custom minter contract to be compatible with the new shared minter suite, if needed.
+
+### 2. Deploy the custom minter contract
+
+The Engine partner will need to deploy the custom minter contract to the desired network.
+
+### 3. Allowlist the minter for the core contract on the shared minter filter contract
+
+The Engine partner will need to allowlist the custom minter contract for their contract, on the shared minter filter contract. This is done by doing the following:
+
+- Engine Admin calls `approveMinterForContract` on the shared minter filter contract, passing in the address of their core contract, and the custom minter contract
+
+The custom minter is now ready to be used by projects on the Engine partner's core contract!
+
+### 4. Artist configures the custom minter for their project
+
+The artist will need to configure the custom minter for their project. Custom, one-off minters are not indexed by the Art Blocks subgraph (due to the minter being arbitrary and open-ended), so the artist will need to configure the custom minter via the Engine partner's frontend, etherscan, etc. Note that the typical minter filter function for setting a minter for a project, `setMinterForProject` should be used by the artist or admin to assign the custom minter for the project.
 
 ## Migration FAQ
 

--- a/art-blocks-engine-onboarding/art-blocks-engine-101/minter-suite-migration-runbook.md
+++ b/art-blocks-engine-onboarding/art-blocks-engine-101/minter-suite-migration-runbook.md
@@ -4,6 +4,10 @@ order: -5
 
 # Minter Suite Migration Runbook
 
+!!!warning
+This documentation is a work in progress. Minter suite migration is ongoing, and initial migrations are being actively worked. Please reach out to the Art Blocks team with any questions.
+!!!
+
 This page provides a step-by-step guide on how to migrate a V3 Art Blocks Engine core contract from the legacy non-shared minter suite to the new shared minter suite. This migration is required for all V3 Engine contracts that want to use the new shared minter suite, which has the following benefits:
 
 - All minter contracts are indexed by the Art Blocks subgraph, and can therefore be configured in the new Artist Dashboard website (coming soon)
@@ -34,9 +38,13 @@ The source code of all new, shared minter contracts is available on the [Art Blo
 - MinterSetPricePolyptychERC20V5
 - MinterDAExpV5
 - MinterDALinV5
-- MinterDAExpSettlementV2
+- MinterDAExpHolderV5
+- MinterDALinHolderV5
+- MinterDAExpSettlementV3
 
+!!!info
 In the coming months, the Art Blocks team will be releasing a new minting SDK that can be used to support the new shared minter suite. Documentation for the SDK will be referenced here when it becomes available.
+!!!
 
 ### 2. Schedule downtime for any live projects
 
@@ -56,17 +64,11 @@ You are now using the new shared minter suite!
 
 **AFTER** step 3, artists must re-configure their minters for **all live projects**. This is a quick process, but requires coordination with artists to ensure they are ready to re-configure their minters after the switch.
 
-Artists can re-configure their minters via the (new) Artist Dashboard. The process for _most_ open projects will likely be to switch to a fixed price minter. The steps to complete switching to a fixed price minter are:
+Artists can re-configure their minters manually by following the instructions documented in the [engine project launch/assigning a minter section](./Engine-project-launch.md#assigning-a-minter-v3-only-new-shared-minter-suite). Additionally, soon, artists will be able to configure their project minters via the (new) Artist Dashboard.
 
-1. Artist navigates to the new Artist Dashboard (while connected with their artist wallet)
-2. (recommended, but not required) Artist pauses their project
-3. Artist selects the "Minter" tab
-4. Artist selects the "Fixed Price ETH" minter and sends transaction to assign the minter to their project
-5. (optional) If max invocations should be limited by the minter, Artist sets max invocations to desired value (sends transaction)
-6. Artist sets the price per per token in wei (sends transaction)
-7. Artist unpauses their project (if paused in step 2) (sends transaction)
+The process for _most_ open projects will likely be to switch to a fixed price minter.
 
-Your project is now using the new shared minter suite and live for minting!
+After configuring a minter, the project is now using the new shared minter suite and live for minting!
 
 ### 5. Engine partner monitors migration progress
 
@@ -124,10 +126,14 @@ If you migrate to the new shared minter suite, you will be able to use any new m
 
 If you do not migrate to the new shared minter suite, nothing will change, but you will miss out on new developments. You will not be able to use any new minters developed for Art Blocks Flagship. Additionally, you will not be able to use the Artist Dashboard to configure your minters, because your minter suite will not be indexed. You will need to continue to use the legacy non-shared minter suite.
 
-### What happens if I migrate to the new shared minter suite, but I do not want to use the Artist Dashboard to configure my minters?
+### What happens if I migrate to the new shared minter suite, but I do not want to use the (coming soon) Artist Dashboard to configure my minters?
+
+There are many reasons why a partner might want to do this!
 
 If you migrate to the new shared minter suite, but you do not want to use the Artist Dashboard to configure your minters, you can continue to configure your minters via your frontend, etherscan, etc., but your process will be slightly updated to support the new shared minter suite. Comparing the new minter contracts and the legacy minter contracts will help you understand the changes.
 
-### What happens if I migrate to the new shared minter suite, but I do not want to use the new minting SDK?
+### What happens if I migrate to the new shared minter suite, but I do not want to use the new (coming soon) minting SDK?
+
+No problem!
 
 If you migrate to the new shared minter suite, but you do not want to use the new minting SDK, you can continue to use your existing minting process, but your process will be slightly updated to support the new shared minter suite.


### PR DESCRIPTION
Update Engine docs with a minter suite migration runbook that explains how to migrate to the new shared minter suite.

Steps are included for:

- steps to migrate from legacy Engine non-shared minter suite to new shared minter suite
- steps to add custom, one-off minters for a single Engine contract to the shared MinterFilter

This PR specifically does not add a runbook tailored to flagship artists for flagship migration. If that communication is desired to be added to the docs site vs. more tailored information being sent in artist communication channels, please highlight this in PR feedback!

This PR states that SDK reference information will be added when it becomes available. It also says that shared randomizer and shared minter filter contract addresses will be as they are deployed to testnets and mainnets.

---

Asana task: https://app.asana.com/0/0/1205139431852181/f