### PR TITLE
Point flagship docs to shared minter suite docs

### DIFF
--- a/creator-onboarding/curated-checklist.md
+++ b/creator-onboarding/curated-checklist.md
@@ -60,7 +60,7 @@ Be sure that you've input information in all field forms. If you do not have an 
 
 We have a variaty of minters available for you to choose from to best suit your project.
 
-For an overview of all minters available for artists, please see the [Minter Suite](readme/minter-suite.md) page.
+For an overview of all minters available for artists, please see the [Shared Minter Suite](./../minter-suite/shared-minter-suite.md) page.
 
 For more detailed instructions on how to configure your selected minter, please see the [Minter section of the Project Form Fields Guide](readme/project-form-fields-guide.md#minter) .
 

--- a/creator-onboarding/presents.md
+++ b/creator-onboarding/presents.md
@@ -60,12 +60,12 @@ Be sure that you've input information in all field forms. If you do not have an 
 
 We have a variaty of minters available for you to choose from to best suit your project.
 
-For an overview of all minters available for artists, please see the [Minter Suite](readme/minter-suite.md) page.
+For an overview of all minters available for artists, please see the [Shared Minter Suite](./../minter-suite/shared-minter-suite.md) page.
 
 For more detailed instructions on how to configure your selected minter, please see the [Minter section of the Project Form Fields Guide](readme/project-form-fields-guide.md#minter) .
 
 !!!info
-If you are using the `Dutch auction - Exponential Price Decrease` (with or without settlement) or `Dutch auction - Linear Price Decrease,` you will need to unpause your project before your auction's start time. Your project can be unpaused under the Danger tab any time prior to the starting time of your auction.  We recommend unpausing projects on the morning of your release. Once unpaused, your project will be marked as “Upcoming,” and the Dutch auction will automatically begin at your start time, leaving the beginning of the auction hands-free.
+If you are using the `Dutch auction - Exponential Price Decrease` (with or without settlement) or `Dutch auction - Linear Price Decrease,` you will need to unpause your project before your auction's start time. Your project can be unpaused under the Danger tab any time prior to the starting time of your auction. We recommend unpausing projects on the morning of your release. Once unpaused, your project will be marked as “Upcoming,” and the Dutch auction will automatically begin at your start time, leaving the beginning of the auction hands-free.
 !!!
 
 ## Scheduling
@@ -82,7 +82,7 @@ Pre-Drop Talks happen on Twitter Spaces 15 minutes prior to the release of your 
 
 - When it's time, you'll click the Unpause button under the Danger tab.
 - You may unpause your Dutch auction release up to 24 hours in advance.
-- For  unpausing fixed price releases, please send in the tx 30 seconds prior to the top of the hour. To unpause the project, please send high gas (2-3x what is suggested as high gas on https://etherscan.io/gastracker). If you have questions about what you should set your gas to, please ask in your project DM and the Art Blocks Team can advise.
+- For unpausing fixed price releases, please send in the tx 30 seconds prior to the top of the hour. To unpause the project, please send high gas (2-3x what is suggested as high gas on https://etherscan.io/gastracker). If you have questions about what you should set your gas to, please ask in your project DM and the Art Blocks Team can advise.
 - Once the transaction clears, your project will be live for minting.
 
 ## Rarities

--- a/creator-onboarding/readme/minter-suite.md
+++ b/creator-onboarding/readme/minter-suite.md
@@ -5,58 +5,6 @@ order: 851
 # Minter Suite
 
 !!!info
-Before the end of 2023, Art Blocks will be transitioning to a new, shared minter suite. This new minter suite will be similar to the current minter suite, but will be more flexible and will enable artists to create more complex minter configurations. The new minter suite will be available for all projects, including Art Blocks Engine projects.
+Art Blocks has migrated to a new, shared minter suite!
 Please see the [Shared Minter Suite](./../../minter-suite/shared-minter-suite.md) page for more details.
-!!!
-
-This page provides an overview of the Art Blocks Minter Suite, which enables artists to choose how they distribute their artwork to collectors. on a per-project basis.
-
-The current available Minter options are discussed below. We are continually expanding our minter suite over time.
-
-!!!info
-For details on determining proper pricing and configuring your project's minter, please see the [Minter section in the Project Form Fields Guide](project-form-fields-guide.md#minter).
-!!!
-
-## `Set Price - ETH`
-
-The set price minter is used for fixed price releases. It is the simplest minter and prices all tokens at the same price, in ETH.
-
-## `Dutch Auction with Settlement - Exponential Price Decrease`
-
-When this minter is used, all collectors will pay the same net-price as the last purchaser. This is typically the most fair and equitable Dutch auction type for buyers because all buyers pay the same price, making it the recommended auction type for most projects.
-
-Collectors who purchase above the lowest price will be able to claim a settlement after the auction. The settlement will be the difference between the price they purchased at and the last purchase price. All funds are held non-custodially by the smart contract until the auction ends and revenues are collected by the artist.
-
-Note that the Dutch auction with settlement minter can be coupled with an allowlist minter. In this case, the allowlist portion of the auction must come before the dutch auction with settlement.
-
-!!!info
-For Art Blocks Flagship, please see the [Project Pricing: Dutch Auction Settings](project-pricing-model.md) section for more information on how to determine the appropriate pricing parameters for your auction.
-!!!
-
-## `Set price in Custom ERC20`
-
-Set price in ERC20 is a fixed price minter that allows accepting any ERC20 token as payment for your sale of tokens. In addition to specifying a fixed price, artists will specify the ERC20 token address for the custom token sale.
-
-## `Set Price - ETH, Allowlisted Users Only`
-
-This minter enables the artist to limit minting of their project's tokens to a predetermined list of wallet addresses. Artists upload a list of allowlisted wallet addresses, and may also specify the number of mints allowed per wallet. Mints per wallet can be set to a value, or may be set to unlimited (limited only by project maximum invocations).
-
-Artists are responsible for crafting their allowlist and uploading a comma-separated list of ETH addresses in a .txt or .CSV file to the artist dashboard. These wallet addresses cannot be ENS names, but list the full address of the wallet. [Premint](https://www.premint.xyz/) is a super helpful tool for creating an allowlist by using social channels to reach collectors, friends, family, etc. In addition, Art Blocks hosts a [Python script](https://github.com/ArtBlocks/artblocks-community-tooling/tree/main/SnapshotABHolders) for retrieving & snapshotting either a list of all Art Blocks token holders or the token-holders of a specific project.
-
-!!!info
-Allowlists use Merkle trees, which enables them to be verified on-chain and to be decentralized. It also is efficient, enabling very large allowlists. For example, ~40,000 wallet addresses were used for the Friendship Bracelet project's allowlist.
-!!!
-
-!!!info
-Note that vault delegation via [Delegate Cash](https://delegate.cash/) is available for the Allowlisted Users minter. For more details please visit this [video walkthrough](https://www.youtube.com/watch?v=2-AgG--zcaw&list=PLSNTJAzmISeZcLm19EhafsGjJXwwgzBbU&index=5).
-!!!
-
-## `Set Price - ETH, Token Holders Only`
-
-This minter allows tokens to be minted with ETH when the purchaser owns a token from one or more allowlisted Art Blocks or Art Blocks Engine project. This contract does not track if a purchaser has/has not minted already (ie. a "mint limit" is not available) -- it simply restricts purchasing to anybody that holds one or more of a specified list of ERC-721 NFTs.
-
-Artists may use the artist dashboard to pre-select a list of allowlisted Art Blocks or Art Blocks Engine projects, of which any valid token holders will be able to purchase for the upcoming project. Note that a "snapshot" won't apply to this minter -- after the project has been made public, users can purchase a token from any allowlisted project and mint freely.
-
-!!!info
-Note that vault delegation via [Delegate Cash](https://delegate.cash/) is available for the Token Holders Only minter. For more details please visit this [video walkthrough](https://www.youtube.com/watch?v=2-AgG--zcaw&list=PLSNTJAzmISeZcLm19EhafsGjJXwwgzBbU&index=5).
 !!!

--- a/creator-onboarding/readme/project-form-fields-guide.md
+++ b/creator-onboarding/readme/project-form-fields-guide.md
@@ -159,7 +159,7 @@ For many artists, the process for writing your features script will likely entai
 ## Minter:
 
 !!!info
-For an overview of all minters available on Art Blocks, please see the [Minter Suite](minter-suite.md) page.
+For an overview of all minters available on Art Blocks, please see the [Shared Minter Suite](./../../minter-suite/shared-minter-suite.md) page.
 !!!
 
 ### Configuring Your Minter ⛽📄


### PR DESCRIPTION
Update flagship docs to reference shared minter suite instead of legacy minter suite.