### PR TITLE
v3.2 docs updates

### DIFF
--- a/core-contract-v3/dashboard.md
+++ b/core-contract-v3/dashboard.md
@@ -1,0 +1,13 @@
+---
+order: 900
+---
+
+# Creator Dashboard
+
+V3 core contracts may be managed by partners, artists and creators using the Art Blocks Creator Dashboard. The dashboard provides a user-friendly interface for managing projects, tokens, and other contract settings. The dashboard is accessible at [https://create.artblocks.io](https://create.artblocks.io).
+
+Various features are available to creators, including:
+
+- **Project Management**: Create, edit, and manage projects.
+- **Project Creation**: Add new projects to your contract.
+- **Payment Management**: Manage payment addresses, view current royalty splitter address, etc.

--- a/core-contract-v3/erc2981-royalties.md
+++ b/core-contract-v3/erc2981-royalties.md
@@ -1,0 +1,15 @@
+---
+order: 900
+---
+
+# ERC-2981 Royalties
+
+For v3.2+ contracts (all Studio contracts, Engine contracts deployed after May 2024), Art Blocks contracts conform to the ERC-2981 standard for royalties.
+
+> Note: All versions of Art Blocks core contracts integrate seamlessly with the Royalty Registry, which is supported by all major secondary marketplaces.
+
+The ERC-2981 standard requires that royalty payments be made to a single address. Art Blocks contracts support this standard by integrating with 0xSplits to facilitate multi-party royalty payments to multiple addresses, all funneled through a single, permissionless, immutable "splitter contract" address.
+
+Artists may view their current royalty splitter address in the Art Blocks Creator Dashboard. The royalty splitter address is deployed and set automatically by the v3.2+ Art Blocks core contract when payment information is configured. A link to the current splitter is available in the dashboard, and distribution of funds in the splitter may be viewed and executed via the 0xSplits website. Note that 0xSplits provides a user-friendly interface for viewing splitter balances and executing distributions, as well as robust report generation tooling.
+
+> Note: 0xSplits is a third-party service and is not affiliated with Art Blocks.

--- a/core-contract-v3/index.yml
+++ b/core-contract-v3/index.yml
@@ -1,0 +1,4 @@
+icon: coins
+label: Core Contract (V3)
+expanded: true
+route: /creator-docs/core-contract-v3/

--- a/core-contract-v3/manual-admin-operations.md
+++ b/core-contract-v3/manual-admin-operations.md
@@ -1,0 +1,25 @@
+---
+order: 900
+---
+
+# Manual Admin Operations
+
+Some rarely used admin operations are not available in the Art Blocks Creator Dashboard. These operations are available via direct interaction with the contract via a service such as Etherscan or Gnosis Safe's Transaction Builder.
+
+A few manual admin operations are detailed below.
+
+## Update provider secondary royalties payment addresses or basis points
+
+> Note: this describes the process for updating provider secondary royalty information - artist updates are handled within the [Art Blocks Creator Dashboard](./dashboard.md).
+
+For all V3 contracts, the contract admin can update the provider secondary royalties payment addresses or basis points by calling any of the following functions on the contract:
+
+- `function updateProviderSalesAddresses`
+- `function updateProviderPrimarySalesPercentages`
+- `function updateProviderSecondarySalesBPS` or `function updateProviderDefaultSecondarySalesBPS` (depending on minor version)
+
+For v3.2+ contracts (deployed after May 2024), the contract admin must also propogate the contract-level changes to every project in the contract by calling the following function on the contract for each project:
+
+- `syncProviderSecondaryForProjectToDefaults(uint256 projectId)`
+
+> Note: The additional step of syncing provider secondary royalties to defaults was added in v3.2 to enable conformance to the ERC-2981 royalty info standard while remaining scalable within ethereum's block gas limit.

--- a/core-contract-v3/overview.md
+++ b/core-contract-v3/overview.md
@@ -1,0 +1,20 @@
+---
+order: 1000
+---
+
+# Overview of V3 Core Contract
+
+The Art Blocks V3 Core Contract allows Art Blocks Curated artists, Studio artists, and Engine partners to create generative art projects on the blockchain. The contract is a shared contract that allows for multiple projects to be created and managed by different artists and creators. The V3 Core Contract is designed to be flexible and extensible, allowing for a wide range of generative art projects to be created.
+
+## Variants
+
+The V3 Core Contract comes in two variants:
+
+- V3 Engine
+- V3 Engine Flex
+
+Both of these implementations are available for use by Art Blocks Studio artists and Engine partners.
+
+The V3 Engine contract offers the same functionality as the original Art Blocks contract, with an artist's script being fully defined only on the blockchain. The V3 Engine Flex extends the ways artists may store additional metadata, with options of using re-usable on-chain assets, using decentralized storage networks such as IPFS or Arweave, or pointing to assets defined on the Art Blocks Dependency Registry (some of which are fully defined on-chain, some of which are defined on preferred CDN services).
+
+For more discussion about different NFT metadata storage mechanisms, see the [NFT Metadata Storage at Art Blocks](/art-blocks-101/on-chain.md) page.

--- a/minter-suite/index.yml
+++ b/minter-suite/index.yml
@@ -1,4 +1,4 @@
-icon: coin
+icon: coins
 label: Minter Suite
 expanded: true
 route: /creator-docs/minter-suite/


### PR DESCRIPTION
Update docs for important studio and engine partner info related to the release of v3.2 contract.

A new section of the docs site is added for these updates.