### PR TITLE
Use new Retype features to update the theme and navigation

### DIFF
--- a/retype.yml
+++ b/retype.yml
@@ -2,6 +2,24 @@ input: .
 output: .retype
 url: docs.artblocks.io
 
+start:
+  # Start locally in Pro mode
+  pro: true
+
+nav:
+  mode: stack
+  icons:
+    mode: top
+
+theme:
+  base:
+    base-color: "#9B19EF"
+    base-bg: "#F9F9F9"
+    base-text: "#1E1E1E"
+    base-link-weight: 500
+  dark:
+    base-color: "#D41FD6"
+
 branding:
   title: Art Blocks
   label: Docs


### PR DESCRIPTION
## New features

This pull request updates the `retype.yml` configuration file to enhance the [docs.artblocks.io](https://docs.artblocks.io/) website appearance and functionality. The changes introduce a Pro mode for local development, a new navigation mode, and a customized theme with updated colors and styles.

### Start in `Pro` mode

Adds a configuration to start Retype in [`pro`](https://retype.com/configuration/project/#pro) mode when using `retype start` locally and does not require the Retype Pro key to installed locally.

```yaml
start:
  # Start locally in Pro mode
  pro: true
```

### Use the "Stack" navigation layout

Configure the left-sidebar navigation to use the new [`stack`](https://retype.com/configuration/project/#nav-mode) layout and place the [`icons`](https://retype.com/configuration/project/#nav-icons-mode) at the top.

```yaml
nav:
  mode: stack
  icons:
    mode: top
```

Using the top icon layout keeps the new navigation pattern visible without adding extra configuration overhead for new content sections.

### New theme colors

Customized a few of the new [theme-variables](https://retype.com/configuration/theme-variables/) ([guide](https://retype.com/guides/themes/)) to pick up some of the main artblocks.io website branding.

The colors for the `base-color` theme-variables were pulled from a Squiggle but can easily be customized to any value.

```yaml
theme:
  base:
    base-color: "#9B19EF"
    base-bg: "#F9F9F9"
    base-text: "#1E1E1E"
    base-link-weight: 500
  dark:
    base-color: "#D41FD6"
```

All the latest features added to Retype are available in the [Feature Log](https://retype.com/feature-log/) and release [announcements](https://retype.com/blog/).