### PR TITLE
Add new handy page actions

### DIFF
--- a/retype.yml
+++ b/retype.yml
@@ -25,6 +25,17 @@ links:
     link: /readme.md
     icon: file
 
+actions:
+  items:
+    - text: Copy page
+      action: copy-page-markdown
+      icon: copy
+    - text: Copy link
+      action: copy-page-link
+      icon: link
+    - text: View as Markdown
+      action: view-page-markdown
+      icon: markdown
 
 footer:
   copyright: "&copy; Copyright {{ year }}. All rights reserved."


### PR DESCRIPTION
Add an `actions.items` configuration to `retype.yml` so the docs UI exposes common page actions:

- Copy page
- Copy link
- View as Markdown

With this PR, the page actions button will add the following options:

<img width="220" height="193" alt="image" src="https://github.com/user-attachments/assets/c12e8098-b7e0-4d2e-8186-eadda908efc1" />

More options are possible, such as demonstrated in the following screen capture:

<img width="245" height="361" alt="Screenshot 2026-04-09 at 1 39 45 PM" src="https://github.com/user-attachments/assets/738c7e92-89b1-4898-ac38-01f0b1783df8" />

Let me know if you would like the additional items, such as **Open in ChatGPT**, and I will update the PR.

Hope this helps.
