### PR TITLE
docs: add Markdown formatting guidance for project descriptions

### DIFF
--- a/creator-onboarding/artists/2-staging-and-testing.md
+++ b/creator-onboarding/artists/2-staging-and-testing.md
@@ -88,6 +88,8 @@ The project description is an important opportunity to highlight your intentions
 - Be sure to describe any interactivity features, if applicable.
 - End by summarizing how the medium, outputs, and algorithm achieve your initial inquiry or concept.
 
+For Markdown formatting tips (bold, italics, headers, line breaks), see the [Artist FAQ](/creator-onboarding/artists/faq/#creator-dashboard).
+
 ---
 
 ## Step 3: Scripts

--- a/creator-onboarding/artists/faq.md
+++ b/creator-onboarding/artists/faq.md
@@ -70,6 +70,19 @@ Please note that scripts containing multiple `Canvas` elements may not render as
 **I set up my payment splits wrong. Can I change them?**
 You can update payment configuration up until the project is locked. After locking, the royalty splitter is immutable — contact Art Blocks to request a splitter replacement.
 
+**How do I format my project description? My line breaks aren't working.**
+The description field renders standard Markdown: `**bold**`, `*italics*`, `#`/`##` headers, and links all work. Markdown collapses whitespace by design, so `<br>` tags and trailing double-spaces don't reliably create paragraph breaks. To force a visible blank line between paragraphs, put `&nbsp;` (a non-breaking space) on its own line:
+
+```
+First paragraph.
+
+&nbsp;
+
+Second paragraph.
+```
+
+The Creator Dashboard preview can render slightly differently than the live collection page, so check the live page after publishing to confirm formatting looks right.
+
 ---
 
 ## Staging and Testing


### PR DESCRIPTION
## Summary
- Adds an Artist FAQ entry on Markdown formatting in the project description field, including the `&nbsp;` workaround for paragraph breaks (a recurring artist support question).
- Adds a one-line cross-reference from the "Writing Your Project Description" subsection of the staging guide so artists discover the formatting tip while drafting.

## Background
Artists frequently ask how to insert line breaks in the description field. `<br>` tags and trailing double-spaces don't work because Markdown collapses whitespace; the working pattern is `&nbsp;` on its own line. This documents the supported Markdown (bold, italics, headers, links) alongside the line-break workaround.

## Test plan
- [ ] Render the Retype site locally and confirm the new FAQ entry displays correctly under Creator Dashboard
- [ ] Verify the cross-reference link from `2-staging-and-testing.md` resolves to the right FAQ anchor
- [ ] Confirm the `&nbsp;` example renders as intended in the code block

🤖 Generated with [Claude Code](https://claude.com/claude-code)